### PR TITLE
Update ancillary.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ ELSE()
 ENDIF()
 
 # 设置三方库目录
-SET(THIRD_PARTY_LIBRARY_DIR /root/dev)
+SET(THIRD_PARTY_LIBRARY_DIR /usr/lib)
 
 # 设置编译的头文件搜索目录
 INCLUDE_DIRECTORIES(

--- a/linux/ppp/net/ancillary/ancillary.h
+++ b/linux/ppp/net/ancillary/ancillary.h
@@ -69,8 +69,8 @@ ancil_recv_fds_with_buffer(int, int *, unsigned, void *) noexcept;
 #define ANCIL_FD_BUFFER(n) \
     struct                 \
     {                      \
-        struct cmsghdr h;  \
         int fd[n];         \
+        struct cmsghdr h;  \
     }
 /* ANCIL_FD_BUFFER(n)
  *


### PR DESCRIPTION
Solve compile error with latest linux sys/socket.h

In Linux kernel version newer than Ubuntu 18.04, the sys/socket.h has had some minor changes which leads to the following errors

```
In file included from /usr/include/sys/socket.h:33,
                 from /home/wu2305/repos/openppp2/linux/ppp/net/ancillary/fd_recv.cpp:37:
/usr/include/bits/socket.h: In function ‘int ancil_recv_fds(int, int*, unsigned int)’:
/usr/include/bits/socket.h:290:33: error：flexible array member ‘cmsghdr::__cmsg_data’ not at end of ‘struct ancil_recv_fds(int, int*, unsigned int)::<unnamed>’
  290 |     __extension__ unsigned char __cmsg_data __flexarr; /* Ancillary data.  */
      |                                 ^~~~~~~~~~~
In file included from /home/wu2305/repos/openppp2/linux/ppp/net/ancillary/fd_recv.cpp:44:
/home/wu2305/repos/openppp2/linux/ppp/net/ancillary/ancillary.h:73:13: 附注：next member ‘int ancil_recv_fds(int, int*, unsigned int)::<unnamed struct>::fd [960]’ declared here
   73 |         int fd[n];         \
      |             ^~
/home/wu2305/repos/openppp2/linux/ppp/net/ancillary/fd_recv.cpp:81:5: 附注：in expansion of macro ‘ANCIL_FD_BUFFER’
   81 |     ANCIL_FD_BUFFER(ANCIL_MAX_N_FDS)
      |     ^~~~~~~~~~~~~~~
/home/wu2305/repos/openppp2/linux/ppp/net/ancillary/ancillary.h:71:5: 附注：in the definition of ‘struct ancil_recv_fds(int, int*, unsigned int)::<unnamed>’
   71 |     {                      \
      |     ^
/home/wu2305/repos/openppp2/linux/ppp/net/ancillary/fd_recv.cpp:81:5: 附注：in expansion of macro ‘ANCIL_FD_BUFFER’
   81 |     ANCIL_FD_BUFFER(ANCIL_MAX_N_FDS)
      |     ^~~~~~~~~~~~~~~
/usr/include/bits/socket.h: In function ‘int ancil_recv_fd(int, int*)’:
/usr/include/bits/socket.h:290:33: 错误：flexible array member ‘cmsghdr::__cmsg_data’ not at end of ‘struct ancil_recv_fd(int, int*)::<unnamed>’
  290 |     __extension__ unsigned char __cmsg_data __flexarr; /* Ancillary data.  */
      |                                 ^~~~~~~~~~~
/home/wu2305/repos/openppp2/linux/ppp/net/ancillary/ancillary.h:73:13: 附注：next member ‘int ancil_recv_fd(int, int*)::<unnamed struct>::fd [1]’ declared here
   73 |         int fd[n];         \
      |             ^~
/home/wu2305/repos/openppp2/linux/ppp/net/ancillary/fd_recv.cpp:92:5: 附注：in expansion of macro ‘ANCIL_FD_BUFFER’
   92 |     ANCIL_FD_BUFFER(1)
      |     ^~~~~~~~~~~~~~~
/home/wu2305/repos/openppp2/linux/ppp/net/ancillary/ancillary.h:71:5: 附注：in the definition of ‘struct ancil_recv_fd(int, int*)::<unnamed>’
   71 |     {                      \
      |     ^
/home/wu2305/repos/openppp2/linux/ppp/net/ancillary/fd_recv.cpp:92:5: 附注：in expansion of macro ‘ANCIL_FD_BUFFER’
   92 |     ANCIL_FD_BUFFER(1)
      |     ^~~~~~~~~~~~~~~
```
I have made little modify in the ancillary.h and the libancillary is able to be compiled now