### PR TITLE
Add musl-libc compatibility

### DIFF
--- a/linux/ppp/diagnostics/UnixStackTrace.cpp
+++ b/linux/ppp/diagnostics/UnixStackTrace.cpp
@@ -6,7 +6,7 @@
 #include <cxxabi.h>
 #include <sys/resource.h>
 
-#if !defined(_ANDROID)
+#if (BACKWARD_HAS_BACKTRACE == 1) || (BACKWARD_HAS_BACKTRACE_SYMBOL == 1) 
 #include <execinfo.h>
 #endif
 
@@ -36,7 +36,7 @@ namespace ppp
             return status == 0; /* sudo apt-get remove binutils */
         }
 
-#if !defined(_ANDROID)
+#if (BACKWARD_HAS_BACKTRACE == 1) || (BACKWARD_HAS_BACKTRACE_SYMBOL == 1)
         static ppp::string ExtractSymbol(const char* symbol)
         {
             if (NULL == symbol || *symbol == '\x0')

--- a/linux/ppp/net/ProtectorNetwork.cpp
+++ b/linux/ppp/net/ProtectorNetwork.cpp
@@ -26,8 +26,8 @@
 #include <netinet/in.h>
 #include <sys/time.h>
 #include <netinet/tcp.h>
-#include <error.h>
-#include <sys/poll.h>
+#include <err.h>
+#include <poll.h>
 #endif
 
 #include <fcntl.h>

--- a/ppp/app/protocol/VirtualEthernetLogger.cpp
+++ b/ppp/app/protocol/VirtualEthernetLogger.cpp
@@ -1,3 +1,4 @@
+#define _LARGEFILE64_SOURCE
 #include <ppp/app/protocol/VirtualEthernetLogger.h>
 #include <ppp/DateTime.h>
 #include <ppp/io/File.h>

--- a/ppp/net/Socket.cpp
+++ b/ppp/net/Socket.cpp
@@ -23,7 +23,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
@@ -40,7 +40,7 @@
 #if defined(_MACOS)
 #include <errno.h>
 #elif defined(_LINUX)
-#include <error.h>
+#include <err.h>
 #endif
 
 // https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/ip.h#L26


### PR DESCRIPTION
1. Replace error.h with err.h
2. Make execinfo optional
3. Switch from<sys/poll.h> to <poll.h>