### PR TITLE
Add IPv6 assignment delivery and client/server transit support

### DIFF
--- a/common/unix/UnixAfx.cpp
+++ b/common/unix/UnixAfx.cpp
@@ -58,6 +58,30 @@ namespace ppp {
             return SetDnsAddresses(dns_servers);
         }
 
+        bool UnixAfx::MergeDnsAddresses(const ppp::vector<boost::asio::ip::address>& preferred, const ppp::vector<boost::asio::ip::address>& append) noexcept {
+            ppp::vector<boost::asio::ip::address> merged;
+            auto append_unique = [&merged](const boost::asio::ip::address& address) noexcept {
+                if (IPEndPoint::IsInvalid(address) || address.is_multicast()) {
+                    return;
+                }
+                for (const auto& current : merged) {
+                    if (current == address) {
+                        return;
+                    }
+                }
+                merged.emplace_back(address);
+            };
+
+            for (const auto& address : preferred) {
+                append_unique(address);
+            }
+            for (const auto& address : append) {
+                append_unique(address);
+            }
+
+            return SetDnsAddresses(merged);
+        }
+
         bool UnixAfx::SetDnsAddresses(const ppp::vector<ppp::string>& addresses) noexcept {
             ppp::string content;
             for (size_t i = 0, l = addresses.size(); i < l; i++) {

--- a/common/unix/UnixAfx.h
+++ b/common/unix/UnixAfx.h
@@ -22,6 +22,7 @@ namespace ppp
             static bool                                                         SetDnsAddresses(const ppp::vector<uint32_t>& addresses) noexcept;
             static bool                                                         SetDnsAddresses(const ppp::vector<ppp::string>& addresses) noexcept;
             static bool                                                         SetDnsAddresses(const ppp::vector<boost::asio::ip::address>& addresses) noexcept;
+            static bool                                                         MergeDnsAddresses(const ppp::vector<boost::asio::ip::address>& preferred, const ppp::vector<boost::asio::ip::address>& append) noexcept;
 
         public:
             static ppp::string                                                  GetInterfaceName(const ppp::net::IPEndPoint& address) noexcept;

--- a/linux/ppp/tap/TapLinux.cpp
+++ b/linux/ppp/tap/TapLinux.cpp
@@ -200,6 +200,127 @@ namespace ppp {
             return ioctl(ifc_ctl_sock.sock_v4, SIOCSIFNETMASK, &ifr) == 0;
         }
 
+        static bool ExecuteIpCommand(const ppp::string& command) noexcept {
+            if (command.empty()) {
+                return false;
+            }
+
+            int status = system(command.data());
+            return status == 0;
+        }
+
+        bool TapLinux::SetIPv6Address(const ppp::string& ifrName, const ppp::string& addressIP, int prefix_length) noexcept {
+            if (ifrName.empty() || addressIP.empty()) {
+                return false;
+            }
+
+            char command[1200];
+            snprintf(command, sizeof(command), "ip -6 addr replace %s/%d dev %s > /dev/null 2>&1", addressIP.data(), std::max<int>(0, std::min<int>(128, prefix_length)), ifrName.data());
+            return ExecuteIpCommand(command);
+        }
+
+        bool TapLinux::SetMtu(const ppp::string& ifrName, int mtu) noexcept {
+            if (ifrName.empty()) {
+                return false;
+            }
+
+            mtu = std::max<int>(1280, std::min<int>(9000, mtu));
+
+            char command[1200];
+            snprintf(command, sizeof(command), "ip link set dev %s mtu %d > /dev/null 2>&1", ifrName.data(), mtu);
+            return ExecuteIpCommand(command);
+        }
+
+        bool TapLinux::DeleteIPv6Address(const ppp::string& ifrName, const ppp::string& addressIP, int prefix_length) noexcept {
+            if (ifrName.empty() || addressIP.empty()) {
+                return false;
+            }
+
+            char command[1200];
+            snprintf(command, sizeof(command), "ip -6 addr del %s/%d dev %s > /dev/null 2>&1", addressIP.data(), std::max<int>(0, std::min<int>(128, prefix_length)), ifrName.data());
+            return ExecuteIpCommand(command);
+        }
+
+        bool TapLinux::AddRoute6(const ppp::string& ifrName, const ppp::string& addressIP, int prefix_length, const ppp::string& gw) noexcept {
+            if (ifrName.empty() || addressIP.empty()) {
+                return false;
+            }
+
+            char command[1200];
+            if (gw.empty()) {
+                if (addressIP == "::" && prefix_length == 0) {
+                    snprintf(command, sizeof(command), "ip -6 route replace default dev %s metric 1 > /dev/null 2>&1", ifrName.data());
+                }
+                else {
+                    snprintf(command, sizeof(command), "ip -6 route replace %s/%d dev %s > /dev/null 2>&1", addressIP.data(), std::max<int>(0, std::min<int>(128, prefix_length)), ifrName.data());
+                }
+            }
+            else {
+                if (addressIP == "::" && prefix_length == 0) {
+                    snprintf(command, sizeof(command), "ip -6 route replace default via %s dev %s onlink > /dev/null 2>&1", gw.data(), ifrName.data());
+                }
+                else {
+                    snprintf(command, sizeof(command), "ip -6 route replace %s/%d via %s dev %s onlink > /dev/null 2>&1", addressIP.data(), std::max<int>(0, std::min<int>(128, prefix_length)), gw.data(), ifrName.data());
+                }
+            }
+            return ExecuteIpCommand(command);
+        }
+
+        bool TapLinux::DeleteRoute6(const ppp::string& ifrName, const ppp::string& addressIP, int prefix_length, const ppp::string& gw) noexcept {
+            if (ifrName.empty() || addressIP.empty()) {
+                return false;
+            }
+
+            char command[1200];
+            if (gw.empty()) {
+                if (addressIP == "::" && prefix_length == 0) {
+                    snprintf(command, sizeof(command), "ip -6 route del default dev %s > /dev/null 2>&1", ifrName.data());
+                }
+                else {
+                    snprintf(command, sizeof(command), "ip -6 route del %s/%d dev %s > /dev/null 2>&1", addressIP.data(), std::max<int>(0, std::min<int>(128, prefix_length)), ifrName.data());
+                }
+            }
+            else {
+                if (addressIP == "::" && prefix_length == 0) {
+                    snprintf(command, sizeof(command), "ip -6 route del default via %s dev %s > /dev/null 2>&1", gw.data(), ifrName.data());
+                }
+                else {
+                    snprintf(command, sizeof(command), "ip -6 route del %s/%d via %s dev %s > /dev/null 2>&1", addressIP.data(), std::max<int>(0, std::min<int>(128, prefix_length)), gw.data(), ifrName.data());
+                }
+            }
+            return ExecuteIpCommand(command);
+        }
+
+        bool TapLinux::EnableIPv6NeighborProxy(const ppp::string& ifrName) noexcept {
+            if (ifrName.empty()) {
+                return false;
+            }
+
+            char command[1200];
+            snprintf(command, sizeof(command), "sysctl -w net.ipv6.conf.%s.proxy_ndp=1 > /dev/null 2>&1", ifrName.data());
+            return ExecuteIpCommand(command);
+        }
+
+        bool TapLinux::AddIPv6NeighborProxy(const ppp::string& ifrName, const ppp::string& addressIP) noexcept {
+            if (ifrName.empty() || addressIP.empty()) {
+                return false;
+            }
+
+            char command[1200];
+            snprintf(command, sizeof(command), "ip -6 neigh replace proxy %s dev %s > /dev/null 2>&1", addressIP.data(), ifrName.data());
+            return ExecuteIpCommand(command);
+        }
+
+        bool TapLinux::DeleteIPv6NeighborProxy(const ppp::string& ifrName, const ppp::string& addressIP) noexcept {
+            if (ifrName.empty() || addressIP.empty()) {
+                return false;
+            }
+
+            char command[1200];
+            snprintf(command, sizeof(command), "ip -6 neigh del proxy %s dev %s > /dev/null 2>&1", addressIP.data(), ifrName.data());
+            return ExecuteIpCommand(command);
+        }
+
         ppp::string TapLinux::GetIPAddress(const ppp::string& ifrName) noexcept {
             if (ifrName.empty()) {
                 return "";

--- a/linux/ppp/tap/TapLinux.h
+++ b/linux/ppp/tap/TapLinux.h
@@ -54,6 +54,14 @@ namespace ppp
                 const ppp::string&                                                  ifrName,
                 const ppp::string&                                                  addressIP,
                 const ppp::string&                                                  mask) noexcept;
+            static bool                                                             SetIPv6Address(const ppp::string& ifrName, const ppp::string& addressIP, int prefix_length) noexcept;
+            static bool                                                             SetMtu(const ppp::string& ifrName, int mtu) noexcept;
+            static bool                                                             DeleteIPv6Address(const ppp::string& ifrName, const ppp::string& addressIP, int prefix_length) noexcept;
+            static bool                                                             AddRoute6(const ppp::string& ifrName, const ppp::string& addressIP, int prefix_length, const ppp::string& gw) noexcept;
+            static bool                                                             DeleteRoute6(const ppp::string& ifrName, const ppp::string& addressIP, int prefix_length, const ppp::string& gw) noexcept;
+            static bool                                                             EnableIPv6NeighborProxy(const ppp::string& ifrName) noexcept;
+            static bool                                                             AddIPv6NeighborProxy(const ppp::string& ifrName, const ppp::string& addressIP) noexcept;
+            static bool                                                             DeleteIPv6NeighborProxy(const ppp::string& ifrName, const ppp::string& addressIP) noexcept;
             static ppp::string                                                      GetDeviceId(const ppp::string& ifrName) noexcept;
             static bool                                                             GetPreferredNetworkInterface(ppp::string& interface_, UInt32& address, UInt32& mask, UInt32& gw, const ppp::string& nic) noexcept;
 

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@
 #include <ppp/threading/BufferswapAllocator.h>
 #include <ppp/app/server/VirtualEthernetSwitcher.h>
 #include <ppp/app/server/VirtualEthernetManagedServer.h>
+#include <ppp/app/protocol/VirtualEthernetInformation.h>
 #include <ppp/app/client/VEthernetExchanger.h>
 #include <ppp/app/client/VEthernetNetworkSwitcher.h>
 
@@ -966,6 +967,29 @@ bool PppApplication::PrintEnvironmentInformation() noexcept
                     tmp = ppp::PaddingRight(tmp, 22, ' ');
                     tmp += ": " + ni->DnsAddresses[i].to_string();
                     printfn("%s", tmp.data());
+                }
+
+                if (sti.tun) {
+                    ppp::app::protocol::VirtualEthernetInformationExtensions ipv6_ext;
+                    if (NULLPTR != client) {
+                        ipv6_ext = client->GetInformationExtensions();
+                    }
+
+                    if (ipv6_ext.AssignedIPv6Address.is_v6()) {
+                        printfn("IPv6 Address          : %s/%d", ipv6_ext.AssignedIPv6Address.to_string().data(), (int)ipv6_ext.AssignedIPv6PrefixLength);
+                    }
+                    if (ipv6_ext.AssignedIPv6Gateway.is_v6()) {
+                        printfn("IPv6 Gateway          : %s", ipv6_ext.AssignedIPv6Gateway.to_string().data());
+                    }
+                    if (ipv6_ext.AssignedIPv6PrefixLength > 0) {
+                        printfn("IPv6 Prefix Length    : %d", (int)ipv6_ext.AssignedIPv6PrefixLength);
+                    }
+                    if (ipv6_ext.AssignedIPv6Dns1.is_v6()) {
+                        printfn("IPv6 DNS 1            : %s", ipv6_ext.AssignedIPv6Dns1.to_string().data());
+                    }
+                    if (ipv6_ext.AssignedIPv6Dns2.is_v6()) {
+                        printfn("IPv6 DNS 2            : %s", ipv6_ext.AssignedIPv6Dns2.to_string().data());
+                    }
                 }
 
                 // To print a blank line as a separator for major categories.

--- a/ppp/app/client/VEthernetExchanger.cpp
+++ b/ppp/app/client/VEthernetExchanger.cpp
@@ -18,6 +18,8 @@
 #include <ppp/coroutines/asio/asio.h>
 #include <ppp/coroutines/YieldContext.h>
 #include <ppp/transmissions/ITransmission.h>
+
+static void DebugLog(const char* format, ...) noexcept {}
 #include <ppp/transmissions/ITcpipTransmission.h>
 #include <ppp/transmissions/IWebsocketTransmission.h>
 
@@ -822,22 +824,37 @@ namespace ppp {
             }
 
             bool VEthernetExchanger::OnInformation(const ITransmissionPtr& transmission, const VirtualEthernetInformation& information, YieldContext& y) noexcept {
+                InformationEnvelope envelope;
+                envelope.Base = information;
+                return OnInformation(transmission, envelope, y);
+            }
+
+            bool VEthernetExchanger::OnInformation(const ITransmissionPtr& transmission, const InformationEnvelope& information, YieldContext& y) noexcept {
                 std::shared_ptr<boost::asio::io_context> context = GetContext();
                 if (NULLPTR == context) {
                     return false;
                 }
 
-                auto ei = make_shared_object<VirtualEthernetInformation>(information);
+                auto ei = make_shared_object<VirtualEthernetInformation>(information.Base);
                 if (NULLPTR == ei) {
                     return false;
                 }
                 
                 auto self = shared_from_this();
                 boost::asio::post(*context, 
-                    [self, this, context, ei]() noexcept {
+                    [self, this, context, ei, information]() noexcept {
                         information_ = ei;
                         if (!disposed_) {
-                            switcher_->OnInformation(ei);
+                            DebugLog("client info envelope raw-json=%s", information.ExtendedJson.data());
+                            DebugLog("client info received ipv6 mode=%u prefix=%u flags=%u address=%s gateway=%s dns1=%s dns2=%s",
+                                (unsigned)information.Extensions.AssignedIPv6Mode,
+                                (unsigned)information.Extensions.AssignedIPv6PrefixLength,
+                                (unsigned)information.Extensions.AssignedIPv6Flags,
+                                information.Extensions.AssignedIPv6Address.is_v6() ? information.Extensions.AssignedIPv6Address.to_string().c_str() : "",
+                                information.Extensions.AssignedIPv6Gateway.is_v6() ? information.Extensions.AssignedIPv6Gateway.to_string().c_str() : "",
+                                information.Extensions.AssignedIPv6Dns1.is_v6() ? information.Extensions.AssignedIPv6Dns1.to_string().c_str() : "",
+                                information.Extensions.AssignedIPv6Dns2.is_v6() ? information.Extensions.AssignedIPv6Dns2.to_string().c_str() : "");
+                            switcher_->OnInformation(ei, information.Extensions);
                         }
                     });
                 return true;

--- a/ppp/app/client/VEthernetExchanger.h
+++ b/ppp/app/client/VEthernetExchanger.h
@@ -28,6 +28,7 @@ namespace ppp {
             public:
                 typedef std::shared_ptr<VEthernetNetworkSwitcher>                       VEthernetNetworkSwitcherPtr;
                 typedef ppp::app::protocol::VirtualEthernetInformation                  VirtualEthernetInformation;
+                typedef ppp::app::protocol::VirtualEthernetInformationExtensions        VirtualEthernetInformationExtensions;
                 typedef ppp::auxiliary::UriAuxiliary                                    UriAuxiliary;
                 typedef UriAuxiliary::ProtocolType                                      ProtocolType;
                 typedef ppp::threading::Timer                                           Timer;
@@ -107,6 +108,7 @@ namespace ppp {
                 virtual bool                                                            OnLan(const ITransmissionPtr& transmission, uint32_t ip, uint32_t mask, YieldContext& y) noexcept override;
                 virtual bool                                                            OnNat(const ITransmissionPtr& transmission, Byte* packet, int packet_length, YieldContext& y) noexcept override;
                 virtual bool                                                            OnInformation(const ITransmissionPtr& transmission, const VirtualEthernetInformation& information, YieldContext& y) noexcept override;
+                virtual bool                                                            OnInformation(const ITransmissionPtr& transmission, const InformationEnvelope& information, YieldContext& y) noexcept override;
                 virtual bool                                                            OnPush(const ITransmissionPtr& transmission, int connection_id, Byte* packet, int packet_length, YieldContext& y) noexcept override;
                 virtual bool                                                            OnConnect(const ITransmissionPtr& transmission, int connection_id, const boost::asio::ip::tcp::endpoint& destinationEP, YieldContext& y) noexcept override;
                 virtual bool                                                            OnConnectOK(const ITransmissionPtr& transmission, int connection_id, Byte error_code, YieldContext& y) noexcept override;

--- a/ppp/app/client/VEthernetNetworkSwitcher.cpp
+++ b/ppp/app/client/VEthernetNetworkSwitcher.cpp
@@ -18,6 +18,40 @@
 #include <ppp/net/native/udp.h>
 #include <ppp/net/native/icmp.h>
 #include <ppp/net/native/checksum.h>
+#include <ppp/app/protocol/VirtualEthernetTcpMss.h>
+
+static void DebugLog(const char* format, ...) noexcept {}
+
+#if defined(_LINUX)
+static ppp::string LinuxReadDefaultIPv6Route() noexcept {
+    FILE* pipe = popen("ip -6 route show default 2>/dev/null", "r");
+    if (NULLPTR == pipe) {
+        return ppp::string();
+    }
+
+    char buffer[1024];
+    ppp::string route;
+    while (fgets(buffer, sizeof(buffer), pipe) != NULLPTR) {
+        route.append(buffer);
+    }
+    pclose(pipe);
+
+    while (!route.empty() && (route.back() == '\n' || route.back() == '\r')) {
+        route.pop_back();
+    }
+    return route;
+}
+
+static bool LinuxApplyDefaultIPv6RouteCommand(const ppp::string& route) noexcept {
+    if (route.empty()) {
+        return false;
+    }
+
+    char command[1600];
+    snprintf(command, sizeof(command), "ip -6 route replace %s > /dev/null 2>&1", route.data());
+    return system(command) == 0;
+}
+#endif
 #include <ppp/net/asio/vdns.h>
 #include <ppp/net/Socket.h>
 #include <ppp/net/Ipep.h>
@@ -174,6 +208,26 @@ namespace ppp {
                     if ((destination & mask) != (gw & mask)) {
                         return false;
                     }
+                }
+
+                exchanger->Nat(packet, packet_length);
+                return true;
+            }
+
+            bool VEthernetNetworkSwitcher::OnPacketInput(Byte* packet, int packet_length, bool vnet) noexcept {
+                if (!vnet || NULLPTR == packet || packet_length < 40) {
+                    return false;
+                }
+
+                if ((packet[0] >> 4) != 6) {
+                    return false;
+                }
+
+                app::protocol::ClampTcpMssIPv6(packet, packet_length, app::protocol::ComputeDynamicTcpMss(false, 80));
+
+                std::shared_ptr<VEthernetExchanger> exchanger = exchanger_;
+                if (NULLPTR == exchanger) {
+                    return false;
                 }
 
                 exchanger->Nat(packet, packet_length);
@@ -556,10 +610,301 @@ namespace ppp {
                 return false;
             }
 
+            bool VEthernetNetworkSwitcher::ApplyAssignedIPv6(const VirtualEthernetInformationExtensions& extensions) noexcept {
+                if (ipv6_applied_) {
+                    DebugLog("client ipv6 apply skipped reason=already-applied");
+                    return false;
+                }
+
+                auto tap = GetTap();
+                if (NULLPTR == tap) {
+                    return false;
+                }
+
+                auto tun_ni = tun_ni_;
+                if (NULLPTR == tun_ni) {
+                    DebugLog("client ipv6 apply failed reason=no-tun-interface");
+                    return false;
+                }
+
+                DebugLog("client ipv6 apply begin mode=%u prefix=%u flags=%u address=%s gateway=%s dns1=%s dns2=%s",
+                    (unsigned)extensions.AssignedIPv6Mode,
+                    (unsigned)extensions.AssignedIPv6PrefixLength,
+                    (unsigned)extensions.AssignedIPv6Flags,
+                    extensions.AssignedIPv6Address.is_v6() ? extensions.AssignedIPv6Address.to_string().c_str() : "",
+                    extensions.AssignedIPv6Gateway.is_v6() ? extensions.AssignedIPv6Gateway.to_string().c_str() : "",
+                    extensions.AssignedIPv6Dns1.is_v6() ? extensions.AssignedIPv6Dns1.to_string().c_str() : "",
+                    extensions.AssignedIPv6Dns2.is_v6() ? extensions.AssignedIPv6Dns2.to_string().c_str() : "");
+
+                bool applied = false;
+
+#if defined(_LINUX)
+                if (extensions.AssignedIPv6Mode == VirtualEthernetInformationExtensions::IPv6Mode_Nat && ipv6_original_default_route_restore_.empty()) {
+                    ipv6_original_default_route_restore_ = LinuxReadDefaultIPv6Route();
+                    DebugLog("client ipv6 original default route=%s", ipv6_original_default_route_restore_.empty() ? "<none>" : ipv6_original_default_route_restore_.data());
+                }
+#endif
+
+                if (extensions.AssignedIPv6Address.is_v6()) {
+                    std::string addr_std = extensions.AssignedIPv6Address.to_string();
+                    ppp::string addr_str(addr_std.data(), addr_std.size());
+                    int prefix = std::max<int>(1, std::min<int>(128, (int)extensions.AssignedIPv6PrefixLength));
+                    if (prefix < 1) {
+                        prefix = 64;
+                    }
+
+#if defined(_WIN32)
+                    if (ppp::win32::network::SetIPv6Address(tun_ni->Index, addr_str, prefix)) {
+                        applied = true;
+                    }
+#elif defined(_LINUX)
+                    ppp::tap::TapLinux* linux_tap = dynamic_cast<ppp::tap::TapLinux*>(tap.get());
+                    if (NULLPTR != linux_tap) {
+                        if (ppp::tap::TapLinux::SetIPv6Address(tun_ni->Name, addr_str, prefix)) {
+                            applied = true;
+                            DebugLog("client ipv6 address ok nic=%s address=%s/%d", tun_ni->Name.data(), addr_str.data(), prefix);
+                            if (extensions.AssignedIPv6Mode == VirtualEthernetInformationExtensions::IPv6Mode_Prefix) {
+                                bool route_ok = ppp::tap::TapLinux::AddRoute6(tun_ni->Name, addr_str, prefix, ppp::string());
+                                DebugLog("client ipv6 prefix route %s nic=%s route=%s/%d", route_ok ? "ok" : "fail", tun_ni->Name.data(), addr_str.data(), prefix);
+                            }
+                        }
+                        else {
+                            DebugLog("client ipv6 address fail nic=%s address=%s/%d", tun_ni->Name.data(), addr_str.data(), prefix);
+                        }
+                    }
+#else
+                    // macOS: use ifconfig to set IPv6 address
+                    char cmd[600];
+                    snprintf(cmd, sizeof(cmd), "ifconfig %s inet6 %s prefixlen %d alias", tun_ni->Name.data(), addr_str.data(), prefix);
+                    system(cmd);
+                    applied = true;
+#endif
+                }
+
+                bool ipv6_default_route_handled = false;
+#if defined(_LINUX)
+                if (extensions.AssignedIPv6Mode == VirtualEthernetInformationExtensions::IPv6Mode_Nat && !extensions.AssignedIPv6Gateway.is_v6()) {
+                    ppp::tap::TapLinux* linux_tap = dynamic_cast<ppp::tap::TapLinux*>(tap.get());
+                    if (NULLPTR != linux_tap) {
+                        if (ppp::tap::TapLinux::AddRoute6(tun_ni->Name, "::", 0, ppp::string())) {
+                            applied = true;
+                            ipv6_default_route_handled = true;
+                            DebugLog("client ipv6 default route ok nic=%s gateway=<direct>", tun_ni->Name.data());
+                        }
+                        else {
+                            ipv6_default_route_handled = true;
+                            DebugLog("client ipv6 default route fail nic=%s gateway=<direct>", tun_ni->Name.data());
+                        }
+                    }
+                }
+#endif
+
+                if (!ipv6_default_route_handled && extensions.AssignedIPv6Gateway.is_v6()) {
+                    std::string gw_std = extensions.AssignedIPv6Gateway.to_string();
+                    ppp::string gw_str(gw_std.data(), gw_std.size());
+#if defined(_WIN32)
+                    if (ppp::win32::network::SetIPv6DefaultGateway(tun_ni->Index, gw_str, 0)) {
+                        applied = true;
+                    }
+#elif defined(_LINUX)
+                    ppp::tap::TapLinux* linux_tap = dynamic_cast<ppp::tap::TapLinux*>(tap.get());
+                    if (NULLPTR != linux_tap) {
+                        if (ppp::tap::TapLinux::AddRoute6(tun_ni->Name, "::", 0, gw_str)) {
+                            applied = true;
+                            DebugLog("client ipv6 default route ok nic=%s gateway=%s", tun_ni->Name.data(), gw_str.data());
+                        }
+                        else {
+                            DebugLog("client ipv6 default route fail nic=%s gateway=%s", tun_ni->Name.data(), gw_str.data());
+                        }
+                    }
+#else
+                    // macOS: use route command to add IPv6 default route
+                    char cmd[600];
+                    snprintf(cmd, sizeof(cmd), "route -n add -inet6 default %s", gw_str.data());
+                    system(cmd);
+                    applied = true;
+#endif
+                }
+
+                ppp::vector<ppp::string> dns_servers;
+                if (extensions.AssignedIPv6Dns1.is_v6()) {
+                    std::string dns1_std = extensions.AssignedIPv6Dns1.to_string();
+                    dns_servers.emplace_back(dns1_std.data(), dns1_std.size());
+                }
+                if (extensions.AssignedIPv6Dns2.is_v6()) {
+                    std::string dns2_std = extensions.AssignedIPv6Dns2.to_string();
+                    dns_servers.emplace_back(dns2_std.data(), dns2_std.size());
+                }
+
+                if (!dns_servers.empty()) {
+#if defined(_WIN32)
+                    if (ppp::win32::network::SetDnsAddressesV6(tun_ni->Index, dns_servers)) {
+                        applied = true;
+                        ppp::tap::TapWindows::DnsFlushResolverCache();
+                    }
+#else
+                    ipv6_original_dns_restore_ = ppp::unix__::UnixAfx::GetDnsResolveConfiguration();
+                    ppp::vector<boost::asio::ip::address> dns_addrs;
+                    ppp::vector<boost::asio::ip::address> current_addrs;
+                    ppp::unix__::UnixAfx::GetDnsAddresses(current_addrs);
+                    for (auto& s : dns_servers) {
+                        boost::system::error_code ec;
+                        auto addr = StringToAddress(s, ec);
+                        if (!ec && addr.is_v6()) {
+                            dns_addrs.emplace_back(addr);
+                        }
+                    }
+                    if (!dns_addrs.empty()) {
+                        if (ppp::unix__::UnixAfx::MergeDnsAddresses(dns_addrs, current_addrs)) {
+                            applied = true;
+                            DebugLog("client ipv6 dns ok count=%d", (int)dns_addrs.size());
+                        }
+                        else {
+                            DebugLog("client ipv6 dns fail count=%d", (int)dns_addrs.size());
+                        }
+                    }
+#endif
+                }
+                
+                if (applied) {
+                    ipv6_applied_ = true;
+                    DebugLog("client ipv6 apply done");
+                }
+                else {
+                    DebugLog("client ipv6 apply skipped-or-failed");
+                }
+
+                return applied;
+            }
+
+            void VEthernetNetworkSwitcher::RestoreAssignedIPv6() noexcept {
+                if (!ipv6_applied_) {
+                    return;
+                }
+
+                auto tap = GetTap();
+                if (NULLPTR == tap) {
+                    ipv6_applied_ = false;
+                    return;
+                }
+
+                auto tun_ni = tun_ni_;
+                if (NULLPTR == tun_ni) {
+                    ipv6_applied_ = false;
+                    return;
+                }
+
+                auto& ext = information_extensions_;
+
+                bool ipv6_default_route_cleared = false;
+#if defined(_LINUX)
+                if (ext.AssignedIPv6Mode == VirtualEthernetInformationExtensions::IPv6Mode_Nat && !ext.AssignedIPv6Gateway.is_v6()) {
+                    ppp::tap::TapLinux* linux_tap = dynamic_cast<ppp::tap::TapLinux*>(tap.get());
+                    if (NULLPTR != linux_tap) {
+                        ppp::tap::TapLinux::DeleteRoute6(tun_ni->Name, "::", 0, ppp::string());
+                        ipv6_default_route_cleared = true;
+                    }
+                }
+#endif
+
+                if (!ipv6_default_route_cleared && ext.AssignedIPv6Gateway.is_v6()) {
+                    std::string gw_std = ext.AssignedIPv6Gateway.to_string();
+                    ppp::string gw_str(gw_std.data(), gw_std.size());
+#if defined(_WIN32)
+                    ppp::win32::network::DeleteIPv6DefaultGateway(tun_ni->Index);
+#elif defined(_LINUX)
+                    ppp::tap::TapLinux* linux_tap = dynamic_cast<ppp::tap::TapLinux*>(tap.get());
+                    if (NULLPTR != linux_tap) {
+                        ppp::tap::TapLinux::DeleteRoute6(tun_ni->Name, "::", 0, gw_str);
+                    }
+#else
+                    // macOS: delete IPv6 default route
+                    char cmd[600];
+                    snprintf(cmd, sizeof(cmd), "route -n delete -inet6 default %s", gw_str.data());
+                    system(cmd);
+#endif
+                }
+
+                if (ext.AssignedIPv6Address.is_v6()) {
+                    std::string addr_std = ext.AssignedIPv6Address.to_string();
+                    ppp::string addr_str(addr_std.data(), addr_std.size());
+                    int prefix = std::max<int>(1, std::min<int>(128, (int)ext.AssignedIPv6PrefixLength));
+#if defined(_WIN32)
+                    ppp::win32::network::DeleteIPv6Address(tun_ni->Index, addr_str);
+#elif defined(_LINUX)
+                    ppp::tap::TapLinux* linux_tap = dynamic_cast<ppp::tap::TapLinux*>(tap.get());
+                    if (NULLPTR != linux_tap) {
+                        if (ext.AssignedIPv6Mode == VirtualEthernetInformationExtensions::IPv6Mode_Prefix) {
+                            ppp::tap::TapLinux::DeleteRoute6(tun_ni->Name, addr_str, prefix, ppp::string());
+                        }
+                        ppp::tap::TapLinux::DeleteIPv6Address(tun_ni->Name, addr_str, prefix);
+                    }
+#else
+                    char cmd[600];
+                    snprintf(cmd, sizeof(cmd), "ifconfig %s inet6 %s delete", tun_ni->Name.data(), addr_str.data());
+                    system(cmd);
+#endif
+                }
+                else if (ext.AssignedIPv6Mode == VirtualEthernetInformationExtensions::IPv6Mode_Nat) {
+#if defined(_LINUX)
+                    ppp::tap::TapLinux* linux_tap = dynamic_cast<ppp::tap::TapLinux*>(tap.get());
+                    if (NULLPTR != linux_tap) {
+                        ppp::tap::TapLinux::DeleteRoute6(tun_ni->Name, "::", 0, ppp::string());
+                    }
+#endif
+                }
+
+#if defined(_WIN32)
+                // Windows: clear IPv6 DNS by setting empty, then flush
+                ppp::vector<ppp::string> empty_dns;
+                ppp::win32::network::SetDnsAddressesV6(tun_ni->Index, empty_dns);
+                ppp::tap::TapWindows::DnsFlushResolverCache();
+#else
+                // Linux: restore original DNS configuration
+                if (!ipv6_original_dns_restore_.empty()) {
+                    ppp::unix__::UnixAfx::SetDnsResolveConfiguration(ipv6_original_dns_restore_);
+                }
+#if defined(_LINUX)
+                if (!ipv6_original_default_route_restore_.empty()) {
+                    LinuxApplyDefaultIPv6RouteCommand(ipv6_original_default_route_restore_);
+                }
+#endif
+#endif
+
+                ipv6_applied_ = false;
+                ipv6_original_dns_restore_.clear();
+                ipv6_original_default_route_restore_.clear();
+            }
+
             bool VEthernetNetworkSwitcher::OnInformation(const std::shared_ptr<VirtualEthernetInformation>& info) noexcept {
+                VirtualEthernetInformationExtensions extensions;
+                extensions.Clear();
+                return OnInformation(info, extensions);
+            }
+
+            bool VEthernetNetworkSwitcher::OnInformation(const std::shared_ptr<VirtualEthernetInformation>& info, const VirtualEthernetInformationExtensions& extensions) noexcept {
                 std::shared_ptr<VEthernetExchanger> exchanger = exchanger_;
                 if (NULLPTR == exchanger) {
                     return false;
+                }
+
+                DebugLog("client switcher info ipv6 mode=%u prefix=%u flags=%u address=%s gateway=%s dns1=%s dns2=%s",
+                    (unsigned)extensions.AssignedIPv6Mode,
+                    (unsigned)extensions.AssignedIPv6PrefixLength,
+                    (unsigned)extensions.AssignedIPv6Flags,
+                    extensions.AssignedIPv6Address.is_v6() ? extensions.AssignedIPv6Address.to_string().c_str() : "",
+                    extensions.AssignedIPv6Gateway.is_v6() ? extensions.AssignedIPv6Gateway.to_string().c_str() : "",
+                    extensions.AssignedIPv6Dns1.is_v6() ? extensions.AssignedIPv6Dns1.to_string().c_str() : "",
+                    extensions.AssignedIPv6Dns2.is_v6() ? extensions.AssignedIPv6Dns2.to_string().c_str() : "");
+
+                if (ipv6_applied_ && information_extensions_.ToJson() != extensions.ToJson()) {
+                    RestoreAssignedIPv6();
+                }
+
+                information_extensions_ = extensions;
+
+                if (extensions.HasAny()) {
+                    ApplyAssignedIPv6(extensions);
                 }
 
                 std::shared_ptr<ppp::transmissions::ITransmissionQoS> qos = qos_;
@@ -1905,6 +2250,8 @@ namespace ppp {
 #endif
 
 #if !defined(_ANDROID) && !defined(_IPHONE)
+                RestoreAssignedIPv6();
+
                 // Delete VPN route table information configured in the operating system!
                 if (exchangeof(route_added_, false)) {
                     // Delete routes entries configured by the VPN program from the operating system. 

--- a/ppp/app/client/VEthernetNetworkSwitcher.h
+++ b/ppp/app/client/VEthernetNetworkSwitcher.h
@@ -58,6 +58,7 @@ namespace ppp {
 
             public: 
                 typedef ppp::app::protocol::VirtualEthernetInformation              VirtualEthernetInformation;
+                typedef ppp::app::protocol::VirtualEthernetInformationExtensions    VirtualEthernetInformationExtensions;
                 typedef ppp::app::client::proxys::VEthernetHttpProxySwitcher        VEthernetHttpProxySwitcher;
                 typedef std::shared_ptr<VEthernetHttpProxySwitcher>                 VEthernetHttpProxySwitcherPtr;
                 typedef ppp::app::client::proxys::VEthernetSocksProxySwitcher       VEthernetSocksProxySwitcher;
@@ -124,6 +125,7 @@ namespace ppp {
                 std::shared_ptr<ppp::transmissions::ITransmissionQoS>               GetQoS()                     noexcept { return qos_; }
                 std::shared_ptr<ppp::transmissions::ITransmissionStatistics>        GetStatistics()              noexcept { return statistics_; }
                 std::shared_ptr<VirtualEthernetInformation>                         GetInformation()             noexcept;
+                VirtualEthernetInformationExtensions                                GetInformationExtensions()   noexcept { return information_extensions_; }
                 VEthernetHttpProxySwitcherPtr                                       GetHttpProxy()               noexcept { return http_proxy_; }
                 VEthernetSocksProxySwitcherPtr                                      GetSocksProxy()              noexcept { return socks_proxy_; }
                 RouteInformationTablePtr                                            GetRib()                     noexcept { return rib_; }
@@ -168,10 +170,12 @@ namespace ppp {
 
             protected:  
                 virtual bool                                                        OnPacketInput(ppp::net::native::ip_hdr* packet, int packet_length, int header_length, int proto, bool vnet) noexcept override;
+                virtual bool                                                        OnPacketInput(Byte* packet, int packet_length, bool vnet) noexcept override;
                 virtual bool                                                        OnPacketInput(const std::shared_ptr<IPFrame>& packet) noexcept override;
                 virtual bool                                                        OnTick(uint64_t now) noexcept override;
                 virtual bool                                                        OnUpdate(uint64_t now) noexcept override;
                 virtual bool                                                        OnInformation(const std::shared_ptr<VirtualEthernetInformation>& information) noexcept;
+                virtual bool                                                        OnInformation(const std::shared_ptr<VirtualEthernetInformation>& information, const VirtualEthernetInformationExtensions& extensions) noexcept;
 
             protected:  
                 virtual std::shared_ptr<VEthernetExchanger>                         NewExchanger() noexcept;
@@ -242,6 +246,10 @@ namespace ppp {
                 bool                                                                AddRemoteEndPointToIPList(const boost::asio::ip::address& gw) noexcept;
                 
             private:    
+                bool                                                                ApplyAssignedIPv6(const VirtualEthernetInformationExtensions& extensions) noexcept;
+                void                                                                RestoreAssignedIPv6() noexcept;
+
+            private:    
                 bool                                                                ER(const std::shared_ptr<IPFrame>& packet, const std::shared_ptr<IcmpFrame>& frame, int ttl, const std::shared_ptr<ppp::threading::BufferswapAllocator>& allocator) noexcept;
                 bool                                                                TE(const std::shared_ptr<IPFrame>& packet, const std::shared_ptr<IcmpFrame>& frame, UInt32 source, const std::shared_ptr<ppp::threading::BufferswapAllocator>& allocator) noexcept;
                 bool                                                                ERORTE(int ack_id) noexcept;
@@ -275,6 +283,10 @@ namespace ppp {
                 ppp::string                                                         server_ru_;
                 std::shared_ptr<aggligator::aggligator>                             aggligator_;
                 IForwardingPtr                                                      forwarding_;
+                VirtualEthernetInformationExtensions                                information_extensions_;
+                bool                                                                ipv6_applied_ = false;
+                ppp::string                                                         ipv6_original_dns_restore_;
+                ppp::string                                                         ipv6_original_default_route_restore_;
                 
 #if !defined(_ANDROID) && !defined(_IPHONE)
                 SynchronizedObject                                                  prdr_;

--- a/ppp/app/protocol/VirtualEthernetInformation.cpp
+++ b/ppp/app/protocol/VirtualEthernetInformation.cpp
@@ -1,5 +1,7 @@
 #include <ppp/app/protocol/VirtualEthernetInformation.h>
 
+#include <cstring>
+
 using ppp::auxiliary::JsonAuxiliary;
 
 namespace ppp {
@@ -67,6 +69,104 @@ namespace ppp {
                 this->BandwidthQoS    = 0;
                 this->IncomingTraffic = 0;
                 this->OutgoingTraffic = 0;
+            }
+
+            void VirtualEthernetInformationExtensions::Clear() noexcept {
+                AssignedIPv6Mode = IPv6Mode_None;
+                AssignedIPv6PrefixLength = 0;
+                AssignedIPv6Flags = 0;
+                AssignedIPv6Address = boost::asio::ip::address();
+                AssignedIPv6Gateway = boost::asio::ip::address();
+                AssignedIPv6Dns1 = boost::asio::ip::address();
+                AssignedIPv6Dns2 = boost::asio::ip::address();
+            }
+
+            bool VirtualEthernetInformationExtensions::HasAny() const noexcept {
+                return AssignedIPv6Mode != IPv6Mode_None ||
+                    AssignedIPv6PrefixLength != 0 ||
+                    AssignedIPv6Flags != 0 ||
+                    AssignedIPv6Address.is_v6() ||
+                    AssignedIPv6Gateway.is_v6() ||
+                    AssignedIPv6Dns1.is_v6() ||
+                    AssignedIPv6Dns2.is_v6();
+            }
+
+            void VirtualEthernetInformationExtensions::ToJson(Json::Value& json) const noexcept {
+                json["AssignedIPv6Mode"] = AssignedIPv6Mode;
+                json["AssignedIPv6PrefixLength"] = AssignedIPv6PrefixLength;
+                json["AssignedIPv6Flags"] = AssignedIPv6Flags;
+
+                if (AssignedIPv6Address.is_v6()) {
+                    std::string value = AssignedIPv6Address.to_string();
+                    json["AssignedIPv6Address"] = Json::Value(value.c_str());
+                }
+
+                if (AssignedIPv6Gateway.is_v6()) {
+                    std::string value = AssignedIPv6Gateway.to_string();
+                    json["AssignedIPv6Gateway"] = Json::Value(value.c_str());
+                }
+
+                if (AssignedIPv6Dns1.is_v6()) {
+                    std::string value = AssignedIPv6Dns1.to_string();
+                    json["AssignedIPv6Dns1"] = Json::Value(value.c_str());
+                }
+
+                if (AssignedIPv6Dns2.is_v6()) {
+                    std::string value = AssignedIPv6Dns2.to_string();
+                    json["AssignedIPv6Dns2"] = Json::Value(value.c_str());
+                }
+            }
+
+            ppp::string VirtualEthernetInformationExtensions::ToJson() const noexcept {
+                Json::Value json;
+                ToJson(json);
+                return JsonAuxiliary::ToString(json);
+            }
+
+            bool VirtualEthernetInformationExtensions::FromJson(VirtualEthernetInformationExtensions& value, const ppp::string& json) noexcept {
+                if (json.empty()) {
+                    value.Clear();
+                    return false;
+                }
+
+                return FromJson(value, JsonAuxiliary::FromString(json));
+            }
+
+            bool VirtualEthernetInformationExtensions::FromJson(VirtualEthernetInformationExtensions& value, const Json::Value& json) noexcept {
+                value.Clear();
+                if (!json.isObject()) {
+                    return false;
+                }
+
+                value.AssignedIPv6Mode = static_cast<Byte>(JsonAuxiliary::AsInt64(json["AssignedIPv6Mode"], 0));
+                value.AssignedIPv6PrefixLength = static_cast<Byte>(JsonAuxiliary::AsInt64(json["AssignedIPv6PrefixLength"], 0));
+                value.AssignedIPv6Flags = static_cast<Byte>(JsonAuxiliary::AsInt64(json["AssignedIPv6Flags"], 0));
+
+                boost::system::error_code ec;
+                boost::asio::ip::address address = StringToAddress(JsonAuxiliary::AsString(json["AssignedIPv6Address"]), ec);
+                if (!ec && address.is_v6()) {
+                    value.AssignedIPv6Address = address;
+                }
+
+                ec.clear();
+                address = StringToAddress(JsonAuxiliary::AsString(json["AssignedIPv6Gateway"]), ec);
+                if (!ec && address.is_v6()) {
+                    value.AssignedIPv6Gateway = address;
+                }
+
+                ec.clear();
+                address = StringToAddress(JsonAuxiliary::AsString(json["AssignedIPv6Dns1"]), ec);
+                if (!ec && address.is_v6()) {
+                    value.AssignedIPv6Dns1 = address;
+                }
+
+                ec.clear();
+                address = StringToAddress(JsonAuxiliary::AsString(json["AssignedIPv6Dns2"]), ec);
+                if (!ec && address.is_v6()) {
+                    value.AssignedIPv6Dns2 = address;
+                }
+
+                return value.HasAny();
             }
         }
     }

--- a/ppp/app/protocol/VirtualEthernetInformation.h
+++ b/ppp/app/protocol/VirtualEthernetInformation.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <ppp/stdafx.h>
 #include <ppp/auxiliary/JsonAuxiliary.h>
+#include <ppp/net/IPEndPoint.h>
 
 namespace ppp {
     namespace app {
@@ -26,8 +28,6 @@ namespace ppp {
                 void                                                ToJson(Json::Value& json) noexcept;
                 ppp::string                                         ToJson() noexcept;
                 ppp::string                                         ToString() noexcept;
-
-            public:
                 bool                                                Valid() noexcept                                          { return Valid((UInt32)(GetTickCount() / 1000)); }
                 bool                                                Valid(UInt32 now) noexcept                                { return Valid(this, now); }
                 static bool                                         Valid(VirtualEthernetInformation* i, UInt32 now) noexcept { return (i->IncomingTraffic > 0 && i->OutgoingTraffic > 0) && (i->ExpiredTime != 0 && i->ExpiredTime > now); }
@@ -37,6 +37,35 @@ namespace ppp {
                 static std::shared_ptr<VirtualEthernetInformation>  FromJson(const Json::Value& json) noexcept;
             };
 #pragma pack(pop)
+
+            struct VirtualEthernetInformationExtensions {
+                enum IPv6Mode {
+                    IPv6Mode_None                                      = 0,
+                    IPv6Mode_Prefix                                    = 1,
+                    IPv6Mode_Nat                                       = 2,
+                };
+
+                enum IPv6Flags {
+                    IPv6Flag_None                                      = 0,
+                    IPv6Flag_RoutedPrefix                              = 1 << 0,
+                    IPv6Flag_NeighborProxy                             = 1 << 1,
+                };
+
+                Byte                                                AssignedIPv6Mode = IPv6Mode_None;
+                Byte                                                AssignedIPv6PrefixLength = 0;
+                Byte                                                AssignedIPv6Flags = 0;
+                boost::asio::ip::address                            AssignedIPv6Address;
+                boost::asio::ip::address                            AssignedIPv6Gateway;
+                boost::asio::ip::address                            AssignedIPv6Dns1;
+                boost::asio::ip::address                            AssignedIPv6Dns2;
+
+                void                                                Clear() noexcept;
+                bool                                                HasAny() const noexcept;
+                void                                                ToJson(Json::Value& json) const noexcept;
+                ppp::string                                         ToJson() const noexcept;
+                static bool                                         FromJson(VirtualEthernetInformationExtensions& value, const ppp::string& json) noexcept;
+                static bool                                         FromJson(VirtualEthernetInformationExtensions& value, const Json::Value& json) noexcept;
+            };
         }
     }
 }

--- a/ppp/app/protocol/VirtualEthernetLinklayer.cpp
+++ b/ppp/app/protocol/VirtualEthernetLinklayer.cpp
@@ -656,14 +656,23 @@ namespace ppp {
                 }
                 else if (packet_action == PacketAction_INFO) {           // Virtual Ethernet information
                     if (packet_length >= static_cast<int>(sizeof(VirtualEthernetInformation))) {
-                        VirtualEthernetInformation info = *reinterpret_cast<VirtualEthernetInformation*>(p);
+                        InformationEnvelope info;
+                        info.Base = *reinterpret_cast<VirtualEthernetInformation*>(p);
 
                         // convert from network byte order to host byte order
-                        info.BandwidthQoS   = ppp::net::Ipep::NetworkToHostOrder(info.BandwidthQoS);
-                        info.ExpiredTime    = ntohl(info.ExpiredTime);
-                        info.IncomingTraffic= ppp::net::Ipep::NetworkToHostOrder(info.IncomingTraffic);
-                        info.OutgoingTraffic= ppp::net::Ipep::NetworkToHostOrder(info.OutgoingTraffic);
-                        return OnInformation(transmission, info, y);
+                        info.Base.BandwidthQoS    = ppp::net::Ipep::NetworkToHostOrder(info.Base.BandwidthQoS);
+                        info.Base.ExpiredTime     = ntohl(info.Base.ExpiredTime);
+                        info.Base.IncomingTraffic = ppp::net::Ipep::NetworkToHostOrder(info.Base.IncomingTraffic);
+                        info.Base.OutgoingTraffic = ppp::net::Ipep::NetworkToHostOrder(info.Base.OutgoingTraffic);
+
+                        p += sizeof(VirtualEthernetInformation);
+                        packet_length -= sizeof(VirtualEthernetInformation);
+                        if (packet_length > 0) {
+                            info.ExtendedJson.assign(reinterpret_cast<char*>(p), packet_length);
+                            VirtualEthernetInformationExtensions::FromJson(info.Extensions, info.ExtendedJson);
+                        }
+
+                        return OnInformation(transmission, static_cast<const InformationEnvelope&>(info), y);
                     } else {
                         return packet_length == 0;
                     }
@@ -816,17 +825,39 @@ namespace ppp {
             // ---------------------------------------------------------------------
             // Send virtual Ethernet information structure (converted to network byte order).
             // ---------------------------------------------------------------------
-            bool VirtualEthernetLinklayer::DoInformation(const ITransmissionPtr& transmission, const VirtualEthernetInformation& information, YieldContext& y) noexcept 
-            {
-                VirtualEthernetInformation info;
+            bool VirtualEthernetLinklayer::DoInformation(const ITransmissionPtr& transmission, const VirtualEthernetInformation& information, YieldContext& y) noexcept {
+                InformationEnvelope envelope;
+                envelope.Base = information;
+                return DoInformation(transmission, envelope, y);
+            }
+
+            bool VirtualEthernetLinklayer::DoInformation(const ITransmissionPtr& transmission, const InformationEnvelope& information, YieldContext& y) noexcept {
+                VirtualEthernetInformation info = information.Base;
 
                 // convert host byte order to network byte order for transmission
-                info.BandwidthQoS    = ppp::net::Ipep::HostToNetworkOrder(information.BandwidthQoS);
-                info.ExpiredTime     = htonl(information.ExpiredTime);
-                info.IncomingTraffic = ppp::net::Ipep::HostToNetworkOrder(information.IncomingTraffic);
-                info.OutgoingTraffic = ppp::net::Ipep::HostToNetworkOrder(information.OutgoingTraffic);
-                return global::PACKET_Push(PacketAction_INFO, transmission, 
-                                           reinterpret_cast<Byte*>(&info), sizeof(info), y);
+                info.BandwidthQoS    = ppp::net::Ipep::HostToNetworkOrder(info.BandwidthQoS);
+                info.ExpiredTime     = htonl(info.ExpiredTime);
+                info.IncomingTraffic = ppp::net::Ipep::HostToNetworkOrder(info.IncomingTraffic);
+                info.OutgoingTraffic = ppp::net::Ipep::HostToNetworkOrder(info.OutgoingTraffic);
+
+                MemoryStream ms;
+                if (!ms.Write(&info, 0, sizeof(info))) {
+                    return false;
+                }
+
+                ppp::string extended = information.ExtendedJson;
+                if (extended.empty() && information.Extensions.HasAny()) {
+                    extended = information.Extensions.ToJson();
+                }
+
+                if (!extended.empty()) {
+                    if (!ms.Write(extended.data(), 0, static_cast<int>(extended.size()))) {
+                        return false;
+                    }
+                }
+
+                std::shared_ptr<Byte> buffer = ms.GetBuffer();
+                return global::PACKET_Push(PacketAction_INFO, transmission, buffer.get(), ms.GetPosition(), y);
             }
 
             // ---------------------------------------------------------------------

--- a/ppp/app/protocol/VirtualEthernetLinklayer.h
+++ b/ppp/app/protocol/VirtualEthernetLinklayer.h
@@ -28,6 +28,13 @@ namespace ppp {
             /* Virtual Ethernet Link Layer Protocol Handler */
             class VirtualEthernetLinklayer : public std::enable_shared_from_this<VirtualEthernetLinklayer> {
             public:
+                struct                                                    InformationEnvelope {
+                    VirtualEthernetInformation                            Base;
+                    VirtualEthernetInformationExtensions                  Extensions;
+                    ppp::string                                           ExtendedJson;
+                };
+
+            public:
                 typedef ppp::configurations::AppConfiguration               AppConfiguration;           // Application configuration type
                 typedef std::shared_ptr<AppConfiguration>                   AppConfigurationPtr;        // Shared pointer to configuration
                 typedef ppp::transmissions::ITransmission                   ITransmission;              // Transmission interface type
@@ -101,12 +108,10 @@ namespace ppp {
                 static int                                                  NewId() noexcept;
 
             public:
-                // Send LAN advertisement (IP and mask)
                 virtual bool                                                DoLan(const ITransmissionPtr& transmission, uint32_t ip, uint32_t mask, YieldContext& y) noexcept;
-                // Send NAT data packet
                 virtual bool                                                DoNat(const ITransmissionPtr& transmission, Byte* packet, int packet_length, YieldContext& y) noexcept;
-                // Send virtual Ethernet information structure
                 virtual bool                                                DoInformation(const ITransmissionPtr& transmission, const VirtualEthernetInformation& information, YieldContext& y) noexcept;
+                virtual bool                                                DoInformation(const ITransmissionPtr& transmission, const InformationEnvelope& information, YieldContext& y) noexcept;
                 // Send TCP data push on a connection
                 virtual bool                                                DoPush(const ITransmissionPtr& transmission, int connection_id, Byte* packet, int packet_length, YieldContext& y) noexcept;
                 // Send TCP connection request using hostname and port
@@ -164,10 +169,10 @@ namespace ppp {
                 virtual bool                                                OnFrpPush(const ITransmissionPtr& transmission, int connection_id, bool in, int remote_port, const void* packet, int packet_length) noexcept { return true; }
 
             protected:
-                // Handlers for core VPN actions (override in derived class)
                 virtual bool                                                OnLan(const ITransmissionPtr& transmission, uint32_t ip, uint32_t mask, YieldContext& y) noexcept { return true; }
                 virtual bool                                                OnNat(const ITransmissionPtr& transmission, Byte* packet, int packet_length, YieldContext& y) noexcept { return true; }
                 virtual bool                                                OnInformation(const ITransmissionPtr& transmission, const VirtualEthernetInformation& information, YieldContext& y) noexcept { return true; }
+                virtual bool                                                OnInformation(const ITransmissionPtr& transmission, const InformationEnvelope& information, YieldContext& y) noexcept { return OnInformation(transmission, information.Base, y); }
                 virtual bool                                                OnPush(const ITransmissionPtr& transmission, int connection_id, Byte* packet, int packet_length, YieldContext& y) noexcept { return true; }
                 virtual bool                                                OnConnect(const ITransmissionPtr& transmission, int connection_id, const boost::asio::ip::tcp::endpoint& destinationEP, YieldContext& y) noexcept { return true; }
                 virtual bool                                                OnConnectOK(const ITransmissionPtr& transmission, int connection_id, Byte error_code, YieldContext& y) noexcept { return true; }

--- a/ppp/app/protocol/VirtualEthernetTcpMss.h
+++ b/ppp/app/protocol/VirtualEthernetTcpMss.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <ppp/stdafx.h>
+#include <ppp/net/native/ip.h>
+#include <ppp/net/native/tcp.h>
+#include <ppp/net/native/checksum.h>
+#include <ppp/app/server/VirtualEthernetIPv6.h>
+
+namespace ppp {
+    namespace app {
+        namespace protocol {
+            static inline unsigned short ComputeDynamicTcpMss(bool ipv4, int tunnel_overhead) noexcept {
+                int base_mtu = ppp::tap::ITap::Mtu;
+                tunnel_overhead = std::max<int>(0, tunnel_overhead);
+                int ip_header = ipv4 ? 20 : 40;
+                int tcp_header = 20;
+                int mss = base_mtu - tunnel_overhead - ip_header - tcp_header;
+
+                if (ipv4) {
+                    mss = std::max<int>(1200, std::min<int>(1460, mss));
+                }
+                else {
+                    mss = std::max<int>(1220, std::min<int>(1440, mss));
+                }
+                return (unsigned short)mss;
+            }
+
+            static inline bool ClampTcpMssIPv4(Byte* packet, int packet_length, unsigned short mss_value) noexcept {
+                if (NULLPTR == packet || packet_length < (int)sizeof(ppp::net::native::ip_hdr)) {
+                    return false;
+                }
+
+                int ip_length = packet_length;
+                ppp::net::native::ip_hdr* iphdr = ppp::net::native::ip_hdr::Parse(packet, ip_length);
+                if (NULLPTR == iphdr || ((iphdr->v_hl & 0x0f) << 2) < ppp::net::native::ip_hdr::IP_HLEN || iphdr->proto != ppp::net::native::ip_hdr::IP_PROTO_TCP) {
+                    return false;
+                }
+
+                int ip_header_length = (iphdr->v_hl & 0x0f) << 2;
+                int tcp_length = ip_length - ip_header_length;
+                if (tcp_length < ppp::net::native::tcp_hdr::TCP_HLEN) {
+                    return false;
+                }
+
+                ppp::net::native::tcp_hdr* tcphdr = reinterpret_cast<ppp::net::native::tcp_hdr*>(packet + ip_header_length);
+                int tcp_header_length = ppp::net::native::tcp_hdr::TCPH_HDRLEN_BYTES(tcphdr);
+                if (tcp_header_length <= ppp::net::native::tcp_hdr::TCP_HLEN || tcp_header_length > tcp_length) {
+                    return false;
+                }
+
+                if ((ppp::net::native::tcp_hdr::TCPH_FLAGS(tcphdr) & ppp::net::native::tcp_hdr::TCP_SYN) == 0) {
+                    return false;
+                }
+
+                Byte* options = reinterpret_cast<Byte*>(tcphdr) + ppp::net::native::tcp_hdr::TCP_HLEN;
+                int options_length = tcp_header_length - ppp::net::native::tcp_hdr::TCP_HLEN;
+                bool changed = false;
+
+                for (int i = 0; i < options_length;) {
+                    Byte kind = options[i];
+                    if (kind == 0) {
+                        break;
+                    }
+                    if (kind == 1) {
+                        i++;
+                        continue;
+                    }
+                    if (i + 1 >= options_length) {
+                        break;
+                    }
+
+                    Byte length = options[i + 1];
+                    if (length < 2 || i + length > options_length) {
+                        break;
+                    }
+
+                    if (kind == 2 && length == 4) {
+                        unsigned short* mss = reinterpret_cast<unsigned short*>(options + i + 2);
+                        unsigned short current = ntohs(*mss);
+                        if (current > mss_value) {
+                            *mss = htons(mss_value);
+                            changed = true;
+                        }
+                        break;
+                    }
+
+                    i += length;
+                }
+
+                if (!changed) {
+                    return false;
+                }
+
+                iphdr->chksum = 0;
+                iphdr->chksum = ppp::net::native::inet_chksum(iphdr, ip_header_length);
+                tcphdr->chksum = 0;
+                tcphdr->chksum = ppp::net::native::inet_chksum_pseudo(reinterpret_cast<unsigned char*>(tcphdr), IPPROTO_TCP, tcp_length, iphdr->src, iphdr->dest);
+                return true;
+            }
+
+            static inline bool ClampTcpMssIPv6(Byte* packet, int packet_length, unsigned short mss_value) noexcept {
+                if (NULLPTR == packet || packet_length < 40 + ppp::net::native::tcp_hdr::TCP_HLEN) {
+                    return false;
+                }
+
+                ppp::app::server::VirtualEthernetIPv6MinimalHeader* ipv6 = reinterpret_cast<ppp::app::server::VirtualEthernetIPv6MinimalHeader*>(packet);
+                if ((ipv6->VersionTrafficClass >> 4) != 6 || ipv6->NextHeader != IPPROTO_TCP) {
+                    return false;
+                }
+
+                boost::asio::ip::address_v6 source;
+                boost::asio::ip::address_v6 destination;
+                if (!ppp::app::server::ParseVirtualEthernetIPv6Header(packet, packet_length, source, destination)) {
+                    return false;
+                }
+
+                ppp::net::native::tcp_hdr* tcphdr = reinterpret_cast<ppp::net::native::tcp_hdr*>(packet + 40);
+                int tcp_length = packet_length - 40;
+                int tcp_header_length = ppp::net::native::tcp_hdr::TCPH_HDRLEN_BYTES(tcphdr);
+                if (tcp_header_length <= ppp::net::native::tcp_hdr::TCP_HLEN || tcp_header_length > tcp_length) {
+                    return false;
+                }
+
+                if ((ppp::net::native::tcp_hdr::TCPH_FLAGS(tcphdr) & ppp::net::native::tcp_hdr::TCP_SYN) == 0) {
+                    return false;
+                }
+
+                Byte* options = reinterpret_cast<Byte*>(tcphdr) + ppp::net::native::tcp_hdr::TCP_HLEN;
+                int options_length = tcp_header_length - ppp::net::native::tcp_hdr::TCP_HLEN;
+                bool changed = false;
+
+                for (int i = 0; i < options_length;) {
+                    Byte kind = options[i];
+                    if (kind == 0) {
+                        break;
+                    }
+                    if (kind == 1) {
+                        i++;
+                        continue;
+                    }
+                    if (i + 1 >= options_length) {
+                        break;
+                    }
+
+                    Byte length = options[i + 1];
+                    if (length < 2 || i + length > options_length) {
+                        break;
+                    }
+
+                    if (kind == 2 && length == 4) {
+                        unsigned short* mss = reinterpret_cast<unsigned short*>(options + i + 2);
+                        unsigned short current = ntohs(*mss);
+                        if (current > mss_value) {
+                            *mss = htons(mss_value);
+                            changed = true;
+                        }
+                        break;
+                    }
+
+                    i += length;
+                }
+
+                if (!changed) {
+                    return false;
+                }
+
+                tcphdr->chksum = 0;
+                tcphdr->chksum = ppp::app::server::VirtualEthernetIPv6PseudoChecksum(reinterpret_cast<unsigned char*>(tcphdr), tcp_length, source, destination, IPPROTO_TCP);
+                return true;
+            }
+        }
+    }
+}

--- a/ppp/app/server/VirtualEthernetExchanger.cpp
+++ b/ppp/app/server/VirtualEthernetExchanger.cpp
@@ -5,6 +5,7 @@
 #include <ppp/app/server/VirtualInternetControlMessageProtocol.h>
 #include <ppp/app/server/VirtualInternetControlMessageProtocolStatic.h>
 #include <ppp/app/server/VirtualEthernetDatagramPortStatic.h>
+#include <ppp/app/server/VirtualEthernetIPv6.h>
 #include <ppp/collections/Dictionary.h>
 #include <ppp/threading/Timer.h>
 #include <ppp/threading/Executors.h>
@@ -32,6 +33,50 @@ typedef ppp::net::packet::IPFrame                                   IPFrame;
 typedef ppp::net::packet::IcmpFrame                                 IcmpFrame;
 typedef ppp::threading::Executors                                   Executors;
 typedef ppp::collections::Dictionary                                Dictionary;
+
+namespace {
+    static bool HandleIPv6GatewayEchoReply(ppp::Byte* packet, int packet_length, const boost::asio::ip::address_v6& gateway) noexcept {
+        if (NULLPTR == packet || packet_length < 48) {
+            return false;
+        }
+
+        ppp::app::server::VirtualEthernetIPv6MinimalHeader* header = reinterpret_cast<ppp::app::server::VirtualEthernetIPv6MinimalHeader*>(packet);
+        if ((header->VersionTrafficClass >> 4) != 6 || header->NextHeader != IPPROTO_ICMPV6) {
+            return false;
+        }
+
+        boost::asio::ip::address_v6 source;
+        boost::asio::ip::address_v6 destination;
+        if (!ppp::app::server::ParseVirtualEthernetIPv6Header(packet, packet_length, source, destination)) {
+            return false;
+        }
+
+        if (destination != gateway) {
+            return false;
+        }
+
+        icmp_hdr* icmp = reinterpret_cast<icmp_hdr*>(packet + 40);
+        int icmp_length = packet_length - 40;
+        if (icmp_length < static_cast<int>(sizeof(icmp_hdr))) {
+            return false;
+        }
+
+        if (icmp->icmp_type != 128 || icmp->icmp_code != 0) {
+            return false;
+        }
+
+        boost::asio::ip::address_v6::bytes_type source_bytes = source.to_bytes();
+        boost::asio::ip::address_v6::bytes_type gateway_bytes = gateway.to_bytes();
+        memcpy(header->Source, gateway_bytes.data(), gateway_bytes.size());
+        memcpy(header->Destination, source_bytes.data(), source_bytes.size());
+        header->HopLimit = 64;
+
+        icmp->icmp_type = 129;
+        icmp->icmp_chksum = 0;
+        icmp->icmp_chksum = ppp::app::server::VirtualEthernetIPv6PseudoChecksum(reinterpret_cast<unsigned char*>(icmp), icmp_length, gateway, source, IPPROTO_ICMPV6);
+        return true;
+    }
+}
 
 namespace ppp {
     namespace app {
@@ -132,6 +177,12 @@ namespace ppp {
                 Dictionary::ReleaseAllObjects(static_echo_datagram_ports);
 
                 static_allocated_context_.reset();
+                if (switcher_) {
+                    VirtualEthernetInformationExtensions extensions;
+                    if (switcher_->BuildInformationIPv6Extensions(GetId(), extensions)) {
+                        switcher_->DeleteIPv6Exchanger(GetId(), extensions.AssignedIPv6Address);
+                    }
+                }
                 switcher_->DeleteExchanger(this);
                 switcher_->DeleteNatInformation(this, address_);
                 switcher_->StaticEchoUnallocated(static_echo_session_id_.exchange(0));
@@ -173,6 +224,10 @@ namespace ppp {
             }
 
             bool VirtualEthernetExchanger::OnInformation(const ITransmissionPtr& transmission, const VirtualEthernetInformation& information, YieldContext& y) noexcept {
+                return false; // Immediate return false and forcefully close the connection due to a suspected malicious attack on the server.
+            }
+
+            bool VirtualEthernetExchanger::OnInformation(const ITransmissionPtr& transmission, const InformationEnvelope& information, YieldContext& y) noexcept {
                 return false; // Immediate return false and forcefully close the connection due to a suspected malicious attack on the server.
             }
 
@@ -251,11 +306,54 @@ namespace ppp {
 
             bool VirtualEthernetExchanger::OnNat(const ITransmissionPtr& transmission, Byte* packet, int packet_length, YieldContext& y) noexcept {
                 AppConfigurationPtr configuration = GetConfiguration();
+                bool forwarded = false;
                 if (configuration->server.subnet) {
-                    ForwardNatPacketToDestination(packet, packet_length, y);
+                    forwarded = ForwardNatPacketToDestination(packet, packet_length, y);
+                }
+
+                if (!forwarded) {
+                    ForwardIPv6PacketToDestination(packet, packet_length, y);
                 }
 
                 return true;
+            }
+
+            bool VirtualEthernetExchanger::ForwardIPv6PacketToDestination(Byte* packet, int packet_length, YieldContext& y) noexcept {
+                if (disposed_) {
+                    return false;
+                }
+
+                boost::asio::ip::address_v6 source;
+                boost::asio::ip::address_v6 destination;
+                if (!ParseVirtualEthernetIPv6Header(packet, packet_length, source, destination)) {
+                    return false;
+                }
+
+                const auto& ipv6 = GetConfiguration()->server.ipv6;
+                boost::system::error_code ec;
+                boost::asio::ip::address gateway = StringToAddress(ipv6.gateway, ec);
+                if (!ec && gateway.is_v6()) {
+                    if (HandleIPv6GatewayEchoReply(packet, packet_length, gateway.to_v6())) {
+                        return DoNat(transmission_, packet, packet_length, y);
+                    }
+                }
+
+                VirtualEthernetSwitcher::VirtualEthernetExchangerPtr exchanger = switcher_->FindIPv6Exchanger(destination);
+                if (NULLPTR == exchanger) {
+                    return switcher_->SendIPv6TransitPacket(packet, packet_length);
+                }
+
+                ITransmissionPtr transmission = exchanger->GetTransmission();
+                if (NULLPTR == transmission) {
+                    return false;
+                }
+
+                if (exchanger->DoNat(transmission, packet, packet_length, y)) {
+                    return true;
+                }
+
+                transmission->Dispose();
+                return false;
             }
 
             bool VirtualEthernetExchanger::OnLan(const ITransmissionPtr& transmission, uint32_t ip, uint32_t mask, YieldContext& y) noexcept {

--- a/ppp/app/server/VirtualEthernetExchanger.h
+++ b/ppp/app/server/VirtualEthernetExchanger.h
@@ -30,6 +30,7 @@ namespace ppp {
 
             public:
                 typedef ppp::app::protocol::VirtualEthernetInformation                      VirtualEthernetInformation;
+                typedef ppp::app::protocol::VirtualEthernetInformationExtensions            VirtualEthernetInformationExtensions;
                 typedef std::shared_ptr<VirtualEthernetSwitcher>                            VirtualEthernetSwitcherPtr;
                 typedef std::shared_ptr<VirtualEthernetDatagramPort>                        VirtualEthernetDatagramPortPtr;
                 typedef std::shared_ptr<VirtualEthernetManagedServer>                       VirtualEthernetManagedServerPtr;
@@ -82,6 +83,7 @@ namespace ppp {
                 virtual bool                                                                OnLan(const ITransmissionPtr& transmission, uint32_t ip, uint32_t mask, YieldContext& y) noexcept override;
                 virtual bool                                                                OnNat(const ITransmissionPtr& transmission, Byte* packet, int packet_length, YieldContext& y) noexcept override;
                 virtual bool                                                                OnInformation(const ITransmissionPtr& transmission, const VirtualEthernetInformation& information, YieldContext& y) noexcept override;
+                virtual bool                                                                OnInformation(const ITransmissionPtr& transmission, const InformationEnvelope& information, YieldContext& y) noexcept override;
                 virtual bool                                                                OnPush(const ITransmissionPtr& transmission, int connection_id, Byte* packet, int packet_length, YieldContext& y) noexcept override;
                 virtual bool                                                                OnConnect(const ITransmissionPtr& transmission, int connection_id, const boost::asio::ip::tcp::endpoint& destinationEP, YieldContext& y) noexcept override;
                 virtual bool                                                                OnConnectOK(const ITransmissionPtr& transmission, int connection_id, Byte error_code, YieldContext& y) noexcept override;
@@ -131,6 +133,7 @@ namespace ppp {
                 bool                                                                        DoMuxEvents() noexcept;
                 bool                                                                        Arp(const ITransmissionPtr& transmission, uint32_t ip, uint32_t mask) noexcept;
                 bool                                                                        ForwardNatPacketToDestination(Byte* packet, int packet_length, YieldContext& y) noexcept;
+                bool                                                                        ForwardIPv6PacketToDestination(Byte* packet, int packet_length, YieldContext& y) noexcept;
                 bool                                                                        SendEchoToDestination(const ITransmissionPtr& transmission, Byte* packet, int packet_length) noexcept;
                 bool                                                                        SendPacketToDestination(const ITransmissionPtr& transmission, const boost::asio::ip::udp::endpoint& sourceEP, const boost::asio::ip::udp::endpoint& destinationEP, Byte* packet, int packet_length, YieldContext& y) noexcept;
     

--- a/ppp/app/server/VirtualEthernetIPv6.h
+++ b/ppp/app/server/VirtualEthernetIPv6.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <ppp/stdafx.h>
+#include <ppp/net/native/checksum.h>
+
+namespace ppp {
+    namespace app {
+        namespace server {
+            struct VirtualEthernetIPv6MinimalHeader {
+                ppp::Byte VersionTrafficClass;
+                ppp::Byte TrafficClassFlow;
+                ppp::UInt16 FlowLabelLow;
+                ppp::UInt16 PayloadLength;
+                ppp::Byte NextHeader;
+                ppp::Byte HopLimit;
+                ppp::Byte Source[16];
+                ppp::Byte Destination[16];
+            };
+
+            static inline bool ParseVirtualEthernetIPv6Header(ppp::Byte* packet, int packet_length, boost::asio::ip::address_v6& source, boost::asio::ip::address_v6& destination) noexcept {
+                if (NULLPTR == packet || packet_length < 40) {
+                    return false;
+                }
+
+                VirtualEthernetIPv6MinimalHeader* header = reinterpret_cast<VirtualEthernetIPv6MinimalHeader*>(packet);
+                if ((header->VersionTrafficClass >> 4) != 6) {
+                    return false;
+                }
+
+                boost::asio::ip::address_v6::bytes_type source_bytes;
+                boost::asio::ip::address_v6::bytes_type destination_bytes;
+                memcpy(source_bytes.data(), header->Source, source_bytes.size());
+                memcpy(destination_bytes.data(), header->Destination, destination_bytes.size());
+                source = boost::asio::ip::address_v6(source_bytes);
+                destination = boost::asio::ip::address_v6(destination_bytes);
+                return true;
+            }
+
+            static inline unsigned short VirtualEthernetIPv6PseudoChecksum(unsigned char* payload, unsigned int proto_len, const boost::asio::ip::address_v6& source, const boost::asio::ip::address_v6& destination, unsigned int next_header) noexcept {
+                unsigned int acc = 0;
+                boost::asio::ip::address_v6::bytes_type source_bytes = source.to_bytes();
+                boost::asio::ip::address_v6::bytes_type destination_bytes = destination.to_bytes();
+
+                acc += ppp::net::native::ip_standard_chksum(source_bytes.data(), static_cast<int>(source_bytes.size()));
+                acc = ppp::net::native::FOLD_U32T(acc);
+                acc += ppp::net::native::ip_standard_chksum(destination_bytes.data(), static_cast<int>(destination_bytes.size()));
+                acc = ppp::net::native::FOLD_U32T(acc);
+                return ppp::net::native::inet_cksum_pseudo_base(payload, next_header, proto_len, acc);
+            }
+        }
+    }
+}

--- a/ppp/app/server/VirtualEthernetSwitcher.cpp
+++ b/ppp/app/server/VirtualEthernetSwitcher.cpp
@@ -5,13 +5,21 @@
 #include <ppp/app/server/VirtualEthernetNamespaceCache.h>
 #include <ppp/IDisposable.h>
 #include <ppp/auxiliary/StringAuxiliary.h>
+#include <ppp/cryptography/digest.h>
 #include <ppp/net/Ipep.h>
 #include <ppp/net/Socket.h>
 #include <ppp/net/IPEndPoint.h>
 #include <ppp/net/proxies/sniproxy.h>
+#include <ppp/io/MemoryStream.h>
+#include <ppp/io/File.h>
+#include <ppp/app/protocol/VirtualEthernetTcpMss.h>
 #include <ppp/net/packet/IPFrame.h>
 #include <ppp/net/packet/UdpFrame.h>
 #include <ppp/net/packet/IcmpFrame.h>
+#include <ppp/app/server/VirtualEthernetIPv6.h>
+#if defined(_LINUX)
+#include <linux/ppp/tap/TapLinux.h>
+#endif
 #include <ppp/collections/Dictionary.h>
 #include <ppp/threading/Executors.h>
 #include <ppp/transmissions/ITcpipTransmission.h>
@@ -25,6 +33,8 @@ using ppp::net::AddressFamily;
 using ppp::threading::Executors;
 using ppp::coroutines::YieldContext;
 using ppp::collections::Dictionary;
+
+static void DebugLog(const char* format, ...) noexcept {}
 
 namespace ppp {
     namespace transmissions {
@@ -56,6 +66,476 @@ namespace ppp {
 
             VirtualEthernetSwitcher::~VirtualEthernetSwitcher() noexcept {
                 Finalize();
+            }
+
+            VirtualEthernetSwitcher::InformationEnvelope VirtualEthernetSwitcher::BuildInformationEnvelope(const Int128& session_id, const VirtualEthernetInformation& info) noexcept {
+                InformationEnvelope envelope;
+                envelope.Base = info;
+                BuildInformationIPv6Extensions(session_id, envelope.Extensions);
+                envelope.ExtendedJson = envelope.Extensions.ToJson();
+                DebugLog("server info envelope session=%s json=%s",
+                    auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
+                    envelope.ExtendedJson.data());
+                return envelope;
+            }
+
+            bool VirtualEthernetSwitcher::BuildInformationIPv6Extensions(const Int128& session_id, VirtualEthernetInformationExtensions& extensions) noexcept {
+                extensions.Clear();
+
+                const auto& ipv6 = configuration_->server.ipv6;
+                if (!ipv6.enabled) {
+                    DebugLog("server ipv6 disabled session=%s", auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data());
+                    return false;
+                }
+
+                auto build_stable_ipv6 = [&](boost::asio::ip::address_v6::bytes_type bytes, int prefix_length) noexcept -> bool {
+                    ppp::string seed = ipv6.stable_secret;
+                    if (seed.empty()) {
+                        seed = auxiliary::StringAuxiliary::Int128ToGuidString(session_id);
+                    }
+                    else {
+                        seed.append(":");
+                        seed.append(auxiliary::StringAuxiliary::Int128ToGuidString(session_id));
+                    }
+
+                    ppp::string digest = ppp::cryptography::hash_hmac(seed.data(), static_cast<int>(seed.size()), ppp::cryptography::DigestAlgorithmic_sha256, false, false);
+                    if (digest.size() < 8) {
+                        return false;
+                    }
+
+                    int prefix_bytes = std::max<int>(0, std::min<int>(16, prefix_length >> 3));
+                    int iid_bytes = std::min<int>(8, 16 - prefix_bytes);
+                    for (int i = 0; i < iid_bytes; i++) {
+                        bytes[16 - iid_bytes + i] = static_cast<unsigned char>(digest[i]);
+                    }
+
+                    if (prefix_bytes < 16) {
+                        for (int i = prefix_bytes; i < 16 - iid_bytes; i++) {
+                            bytes[i] = 0;
+                        }
+                    }
+
+                    boost::asio::ip::address_v6 candidate = boost::asio::ip::address_v6(bytes);
+
+                    boost::system::error_code gateway_ec;
+                    boost::asio::ip::address configured_gateway = StringToAddress(ipv6.gateway, gateway_ec);
+                    if (!gateway_ec && configured_gateway.is_v6() && candidate == configured_gateway.to_v6()) {
+                        boost::asio::ip::address_v6::bytes_type candidate_bytes = candidate.to_bytes();
+                        candidate_bytes[15] ^= 0x01;
+                        candidate = boost::asio::ip::address_v6(candidate_bytes);
+                    }
+
+                    extensions.AssignedIPv6Address = candidate;
+                    return true;
+                };
+
+                boost::system::error_code ec;
+
+                ppp::string mode = ToLower(ipv6.mode);
+                DebugLog("server ipv6 build session=%s mode=%s prefix=%s/%d gateway=%s dns1=%s dns2=%s",
+                    auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
+                    mode.data(),
+                    ipv6.prefix.data(),
+                    ipv6.prefix_length,
+                    ipv6.gateway.data(),
+                    ipv6.dns1.data(),
+                    ipv6.dns2.data());
+                if (mode == "nat") {
+                    extensions.AssignedIPv6Mode = VirtualEthernetInformationExtensions::IPv6Mode_Nat;
+                    extensions.AssignedIPv6PrefixLength = static_cast<Byte>(std::max<int>(64, std::min<int>(128, ipv6.prefix_length)));
+
+                    boost::asio::ip::address_v6::bytes_type ula_bytes = {};
+                    ec.clear();
+                    boost::asio::ip::address configured_prefix = StringToAddress(ipv6.prefix, ec);
+                    if (!ec && configured_prefix.is_v6()) {
+                        ula_bytes = configured_prefix.to_v6().to_bytes();
+                    }
+                    else {
+                        ula_bytes[0] = 0xfd;
+                    }
+
+                    if (!build_stable_ipv6(ula_bytes, extensions.AssignedIPv6PrefixLength)) {
+                        extensions.Clear();
+                        DebugLog("server ipv6 build failed session=%s reason=stable-address", auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data());
+                        return false;
+                    }
+
+                    ec.clear();
+                    boost::asio::ip::address gateway = StringToAddress(ipv6.gateway, ec);
+                    if (!ec && gateway.is_v6()) {
+                        extensions.AssignedIPv6Gateway = gateway;
+                    }
+
+                    // NAT mode still carries an explicit virtual gateway so clients can prefer
+                    // `default via <gateway> dev tun0` over direct-device routing.
+
+                    ec.clear();
+                    boost::asio::ip::address dns1 = StringToAddress(ipv6.dns1, ec);
+                    if (!ec && dns1.is_v6()) {
+                        extensions.AssignedIPv6Dns1 = dns1;
+                    }
+
+                    ec.clear();
+                    boost::asio::ip::address dns2 = StringToAddress(ipv6.dns2, ec);
+                    if (!ec && dns2.is_v6()) {
+                        extensions.AssignedIPv6Dns2 = dns2;
+                    }
+
+                    DebugLog("server ipv6 build result session=%s address=%s gateway=%s dns1=%s dns2=%s flags=%u",
+                        auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
+                        extensions.AssignedIPv6Address.is_v6() ? extensions.AssignedIPv6Address.to_string().c_str() : "",
+                        extensions.AssignedIPv6Gateway.is_v6() ? extensions.AssignedIPv6Gateway.to_string().c_str() : "",
+                        extensions.AssignedIPv6Dns1.is_v6() ? extensions.AssignedIPv6Dns1.to_string().c_str() : "",
+                        extensions.AssignedIPv6Dns2.is_v6() ? extensions.AssignedIPv6Dns2.to_string().c_str() : "",
+                        (unsigned)extensions.AssignedIPv6Flags);
+                    return extensions.HasAny();
+                }
+                elif(mode == "prefix") {
+                    extensions.AssignedIPv6Mode = VirtualEthernetInformationExtensions::IPv6Mode_Prefix;
+                    if (ipv6.routed_prefix) {
+                        extensions.AssignedIPv6Flags |= VirtualEthernetInformationExtensions::IPv6Flag_RoutedPrefix;
+                    }
+                    if (ipv6.neighbor_proxy) {
+                        extensions.AssignedIPv6Flags |= VirtualEthernetInformationExtensions::IPv6Flag_NeighborProxy;
+                    }
+                }
+                else {
+                    DebugLog("server ipv6 build failed session=%s reason=invalid-mode mode=%s", auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(), mode.data());
+                    return false;
+                }
+
+                int assigned_prefix_length = ipv6.routed_prefix ? 128 : ipv6.prefix_length;
+                extensions.AssignedIPv6PrefixLength = static_cast<Byte>(std::max<int>(0, std::min<int>(128, assigned_prefix_length)));
+
+                boost::asio::ip::address prefix = StringToAddress(ipv6.prefix, ec);
+                if (ec || !prefix.is_v6()) {
+                    extensions.Clear();
+                    DebugLog("server ipv6 build failed session=%s reason=invalid-prefix prefix=%s", auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(), ipv6.prefix.data());
+                    return false;
+                }
+
+                boost::asio::ip::address_v6::bytes_type bytes = prefix.to_v6().to_bytes();
+                if (!build_stable_ipv6(bytes, extensions.AssignedIPv6PrefixLength)) {
+                    extensions.Clear();
+                    DebugLog("server ipv6 build failed session=%s reason=stable-prefix-address", auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data());
+                    return false;
+                }
+
+                ec.clear();
+                boost::asio::ip::address gateway = StringToAddress(ipv6.gateway, ec);
+                if (!ec && gateway.is_v6()) {
+                    extensions.AssignedIPv6Gateway = gateway;
+                }
+
+                ec.clear();
+                boost::asio::ip::address dns1 = StringToAddress(ipv6.dns1, ec);
+                if (!ec && dns1.is_v6()) {
+                    extensions.AssignedIPv6Dns1 = dns1;
+                }
+
+                ec.clear();
+                boost::asio::ip::address dns2 = StringToAddress(ipv6.dns2, ec);
+                if (!ec && dns2.is_v6()) {
+                    extensions.AssignedIPv6Dns2 = dns2;
+                }
+
+                DebugLog("server ipv6 build result session=%s address=%s gateway=%s dns1=%s dns2=%s flags=%u",
+                    auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
+                    extensions.AssignedIPv6Address.is_v6() ? extensions.AssignedIPv6Address.to_string().c_str() : "",
+                    extensions.AssignedIPv6Gateway.is_v6() ? extensions.AssignedIPv6Gateway.to_string().c_str() : "",
+                    extensions.AssignedIPv6Dns1.is_v6() ? extensions.AssignedIPv6Dns1.to_string().c_str() : "",
+                    extensions.AssignedIPv6Dns2.is_v6() ? extensions.AssignedIPv6Dns2.to_string().c_str() : "",
+                    (unsigned)extensions.AssignedIPv6Flags);
+
+                if (mode == "prefix") {
+                    DebugLog("server ipv6 prefix semantics session=%s routed-prefix=%s neighbor-proxy=%s provider=%s assigned-prefix-length=%u",
+                        auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
+                        ipv6.routed_prefix ? "yes" : "no",
+                        ipv6.neighbor_proxy ? "yes" : "no",
+                        ipv6.neighbor_proxy_provider.empty() ? "kernel" : ipv6.neighbor_proxy_provider.data(),
+                        (unsigned)extensions.AssignedIPv6PrefixLength);
+                }
+
+                return extensions.HasAny();
+            }
+
+            bool VirtualEthernetSwitcher::AddIPv6Exchanger(const Int128& session_id, const boost::asio::ip::address& ip) noexcept {
+                if (!ip.is_v6()) {
+                    return false;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_key(ip_std.data(), ip_std.size());
+
+                VirtualEthernetExchangerPtr exchanger = GetExchanger(session_id);
+                if (NULLPTR == exchanger) {
+                    return false;
+                }
+
+                bool need_ndppd_sync = false;
+                {
+                    SynchronizedObjectScope scope(syncobj_);
+                    for (auto tail = ipv6s_.begin(); tail != ipv6s_.end();) {
+                        VirtualEthernetExchangerPtr current = tail->second;
+                        if (current && current->GetId() == session_id && tail->first != ip_key) {
+                            tail = ipv6s_.erase(tail);
+                        }
+                        else {
+                            ++tail;
+                        }
+                    }
+                    ipv6s_[ip_key] = exchanger;
+                    AddIPv6TransitRoute(ip);
+                    AddIPv6NeighborProxy(ip);
+                    need_ndppd_sync = false;
+                }
+                if (need_ndppd_sync) {
+                    SyncNdppdNeighborProxy();
+                }
+                return true;
+            }
+
+            bool VirtualEthernetSwitcher::DeleteIPv6Exchanger(const Int128& session_id, const boost::asio::ip::address& ip) noexcept {
+                if (!ip.is_v6()) {
+                    return false;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_key(ip_std.data(), ip_std.size());
+
+                bool need_ndppd_sync = false;
+                {
+                    SynchronizedObjectScope scope(syncobj_);
+                    auto tail = ipv6s_.find(ip_key);
+                    if (tail == ipv6s_.end()) {
+                        return false;
+                    }
+
+                    if (tail->second && tail->second->GetId() != session_id) {
+                        return false;
+                    }
+
+                    DeleteIPv6TransitRoute(ip);
+                    DeleteIPv6NeighborProxy(ip);
+                    ipv6s_.erase(tail);
+                    need_ndppd_sync = false;
+                }
+                if (need_ndppd_sync) {
+                    SyncNdppdNeighborProxy();
+                }
+                return true;
+            }
+
+            VirtualEthernetSwitcher::VirtualEthernetExchangerPtr VirtualEthernetSwitcher::FindIPv6Exchanger(const boost::asio::ip::address& ip) noexcept {
+                if (!ip.is_v6()) {
+                    return NULLPTR;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_key(ip_std.data(), ip_std.size());
+
+                SynchronizedObjectScope scope(syncobj_);
+                auto tail = ipv6s_.find(ip_key);
+                return tail == ipv6s_.end() ? NULLPTR : tail->second;
+            }
+
+            bool VirtualEthernetSwitcher::OpenIPv6NeighborProxyIfNeed() noexcept {
+#if defined(_LINUX)
+                const auto& ipv6 = configuration_->server.ipv6;
+                if (!ipv6.enabled || ToLower(ipv6.mode) != "prefix" || !ipv6.neighbor_proxy) {
+                    return true;
+                }
+
+                ppp::string provider = ToLower(ipv6.neighbor_proxy_provider);
+                if (provider.empty()) {
+                    provider = "kernel";
+                }
+
+                DebugLog("server ipv6 neighbor proxy provider=%s", provider.data());
+                if (provider == "ndppd") {
+                    DebugLog("server ipv6 ndppd provider is externally managed; skip in-process config generation");
+                    return true;
+                }
+
+                if (provider == "manual" || provider == "external") {
+                    DebugLog("server ipv6 neighbor proxy provider=%s externally managed; skip in-process setup", provider.data());
+                    return true;
+                }
+
+                if (provider != "kernel") {
+                    DebugLog("server ipv6 neighbor proxy provider=%s not yet implemented in-process", provider.data());
+                    return true;
+                }
+
+                ppp::string uplink_name;
+                UInt32 address = 0;
+                UInt32 mask = 0;
+                UInt32 gw = 0;
+                if (!ppp::tap::TapLinux::GetPreferredNetworkInterface(uplink_name, address, mask, gw, ppp::string())) {
+                    return false;
+                }
+
+                if (!ppp::tap::TapLinux::EnableIPv6NeighborProxy(uplink_name)) {
+                    return false;
+                }
+
+                ipv6_neighbor_proxy_ifname_ = uplink_name;
+                DebugLog("server ipv6 neighbor proxy enabled if=%s", uplink_name.data());
+#endif
+                return true;
+            }
+
+            bool VirtualEthernetSwitcher::SyncNdppdNeighborProxy() noexcept {
+#if defined(_LINUX)
+                const auto& ipv6 = configuration_->server.ipv6;
+                if (!ipv6.enabled || ToLower(ipv6.mode) != "prefix" || !ipv6.neighbor_proxy) {
+                    return true;
+                }
+
+                ppp::string uplink_name;
+                UInt32 address = 0;
+                UInt32 mask = 0;
+                UInt32 gw = 0;
+                if (!ppp::tap::TapLinux::GetPreferredNetworkInterface(uplink_name, address, mask, gw, ppp::string())) {
+                    return false;
+                }
+
+                ppp::string config_path = "/tmp/openppp2-ndppd.conf";
+                ppp::string config_text = "proxy ";
+                config_text += uplink_name;
+                config_text += " {\n";
+
+                int rules = 0;
+                {
+                    SynchronizedObjectScope scope(syncobj_);
+                    for (const auto& [ip_key, exchanger] : ipv6s_) {
+                        if (NULLPTR == exchanger) {
+                            continue;
+                        }
+
+                        config_text += "  rule ";
+                        config_text += ip_key;
+                        config_text += "/128 {\n";
+                        config_text += "    static\n";
+                        config_text += "  }\n";
+                        rules++;
+                    }
+                }
+
+                if (rules < 1) {
+                    config_text += "  rule ";
+                    config_text += ipv6.prefix;
+                    config_text += "/";
+                    config_text += stl::to_string<ppp::string>(ipv6.prefix_length);
+                    config_text += " {\n";
+                    config_text += "    static\n";
+                    config_text += "  }\n";
+                }
+
+                config_text += "}\n";
+
+                if (!ppp::io::File::WriteAllBytes(config_path.data(), config_text.data(), static_cast<int>(config_text.size()))) {
+                    return false;
+                }
+
+                DebugLog("server ipv6 ndppd config synced path=%s uplink=%s rules=%d", config_path.data(), uplink_name.data(), rules);
+                DebugLog("server ipv6 ndppd reload required path=%s", config_path.data());
+#endif
+                return true;
+            }
+
+            bool VirtualEthernetSwitcher::AddIPv6TransitRoute(const boost::asio::ip::address& ip) noexcept {
+#if defined(_LINUX)
+                if (!ip.is_v6()) {
+                    return false;
+                }
+
+                const auto& ipv6 = configuration_->server.ipv6;
+                if (!ipv6.enabled) {
+                    return false;
+                }
+
+                ppp::string mode = ToLower(ipv6.mode);
+                if (!(mode == "nat" || mode == "prefix")) {
+                    return false;
+                }
+
+                ITapPtr tap = ipv6_transit_tap_;
+                if (NULLPTR == tap) {
+                    return false;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_str(ip_std.data(), ip_std.size());
+                bool ok = ppp::tap::TapLinux::AddRoute6(tap->GetId(), ip_str, 128, ppp::string());
+                DebugLog("server ipv6 transit host-route %s name=%s ip=%s/128", ok ? "add-ok" : "add-fail", tap->GetId().data(), ip_str.data());
+                return ok;
+#else
+                return false;
+#endif
+            }
+
+            bool VirtualEthernetSwitcher::DeleteIPv6TransitRoute(const boost::asio::ip::address& ip) noexcept {
+#if defined(_LINUX)
+                if (!ip.is_v6()) {
+                    return false;
+                }
+
+                const auto& ipv6 = configuration_->server.ipv6;
+                if (!ipv6.enabled) {
+                    return false;
+                }
+
+                ppp::string mode = ToLower(ipv6.mode);
+                if (!(mode == "nat" || mode == "prefix")) {
+                    return false;
+                }
+
+                ITapPtr tap = ipv6_transit_tap_;
+                if (NULLPTR == tap) {
+                    return false;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_str(ip_std.data(), ip_std.size());
+                bool ok = ppp::tap::TapLinux::DeleteRoute6(tap->GetId(), ip_str, 128, ppp::string());
+                DebugLog("server ipv6 transit host-route %s name=%s ip=%s/128", ok ? "del-ok" : "del-fail", tap->GetId().data(), ip_str.data());
+                return ok;
+#else
+                return false;
+#endif
+            }
+
+            bool VirtualEthernetSwitcher::AddIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept {
+#if defined(_LINUX)
+                if (!ip.is_v6() || ipv6_neighbor_proxy_ifname_.empty()) {
+                    return false;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_str(ip_std.data(), ip_std.size());
+                bool ok = ppp::tap::TapLinux::AddIPv6NeighborProxy(ipv6_neighbor_proxy_ifname_, ip_str);
+                DebugLog("server ipv6 neighbor proxy %s if=%s ip=%s", ok ? "add-ok" : "add-fail", ipv6_neighbor_proxy_ifname_.data(), ip_str.data());
+                return ok;
+#else
+                return false;
+#endif
+            }
+
+            bool VirtualEthernetSwitcher::DeleteIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept {
+#if defined(_LINUX)
+                if (!ip.is_v6() || ipv6_neighbor_proxy_ifname_.empty()) {
+                    return false;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_str(ip_std.data(), ip_std.size());
+                bool ok = ppp::tap::TapLinux::DeleteIPv6NeighborProxy(ipv6_neighbor_proxy_ifname_, ip_str);
+                DebugLog("server ipv6 neighbor proxy %s if=%s ip=%s", ok ? "del-ok" : "del-fail", ipv6_neighbor_proxy_ifname_.data(), ip_str.data());
+                return ok;
+#else
+                return false;
+#endif
             }
 
             bool VirtualEthernetSwitcher::Run() noexcept {
@@ -253,11 +733,30 @@ namespace ppp {
                     return false;
                 }
 
+                VirtualEthernetInformation fallback_information;
+                const VirtualEthernetInformation* established_information = i.get();
+                if (NULLPTR == established_information && configuration_->server.ipv6.enabled) {
+                    fallback_information.Clear();
+                    fallback_information.BandwidthQoS = 0;
+                    fallback_information.IncomingTraffic = std::numeric_limits<UInt64>::max();
+                    fallback_information.OutgoingTraffic = std::numeric_limits<UInt64>::max();
+                    fallback_information.ExpiredTime = std::numeric_limits<UInt32>::max();
+                    established_information = &fallback_information;
+                    const char* reason = configuration_->server.backend.empty() ? "no-managed-backend" : "managed-info-empty";
+                    DebugLog("server establish using local bootstrap info session=%s", auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data());
+                    DebugLog("server establish info source=local-bootstrap reason=%s session=%s", reason, auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data());
+                }
+
                 bool run = true;
-                if (NULLPTR != i) {
-                    run = channel->DoInformation(transmission, *i, y);
+                if (NULLPTR != established_information) {
+                    InformationEnvelope envelope = BuildInformationEnvelope(session_id, *established_information);
+                    DebugLog("server info send establish session=%s json=%s",
+                        auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
+                        envelope.ExtendedJson.data());
+                    AddIPv6Exchanger(session_id, envelope.Extensions.AssignedIPv6Address);
+                    run = channel->DoInformation(transmission, envelope, y);
                     if (run) {
-                        run = i->Valid();
+                        run = VirtualEthernetInformation::Valid(const_cast<VirtualEthernetInformation*>(established_information), (UInt32)(GetTickCount() / 1000));
                     }
                 }
 
@@ -486,8 +985,10 @@ namespace ppp {
                     CreateAlwaysTimeout() &&
                     CreateFirewall(firewall_rules) &&
                     OpenManagedServerIfNeed() &&
+                    OpenIPv6TransitIfNeed() &&
                     OpenNamespaceCacheIfNeed() &&
-                    OpenDatagramSocket();
+                    OpenDatagramSocket() &&
+                    OpenIPv6NeighborProxyIfNeed();
                 if (ok) {
                     OpenLogger();
                 }
@@ -506,6 +1007,143 @@ namespace ppp {
                     namespace_cache_ = std::move(cache);
                 }
 
+                return true;
+            }
+
+            bool VirtualEthernetSwitcher::SendIPv6TransitPacket(Byte* packet, int packet_length) noexcept {
+                ITapPtr tap = ipv6_transit_tap_;
+                if (NULLPTR == tap || NULLPTR == packet || packet_length < 40) {
+                    return false;
+                }
+
+                return tap->Output(packet, packet_length);
+            }
+
+            bool VirtualEthernetSwitcher::SendIPv6PacketToClient(const ITransmissionPtr& transmission, Byte* packet, int packet_length) noexcept {
+                if (NULLPTR == transmission || NULLPTR == packet || packet_length < 1) {
+                    return false;
+                }
+
+                ppp::io::MemoryStream ms;
+                if (!ms.WriteByte((Byte)app::protocol::VirtualEthernetLinklayer::PacketAction_NAT)) {
+                    return false;
+                }
+
+                if (!ms.Write(packet, 0, packet_length)) {
+                    return false;
+                }
+
+                std::shared_ptr<Byte> buffer = ms.GetBuffer();
+                return transmission->Write(buffer.get(), ms.GetPosition(),
+                    [transmission](bool ok) noexcept {
+                        if (!ok) {
+                            transmission->Dispose();
+                        }
+                    });
+            }
+
+            bool VirtualEthernetSwitcher::ReceiveIPv6TransitPacket(Byte* packet, int packet_length) noexcept {
+                if (NULLPTR == packet || packet_length < 40) {
+                    return false;
+                }
+
+                boost::asio::ip::address_v6 source;
+                boost::asio::ip::address_v6 destination;
+                if (!ParseVirtualEthernetIPv6Header(packet, packet_length, source, destination)) {
+                    return false;
+                }
+
+                VirtualEthernetExchangerPtr exchanger = FindIPv6Exchanger(destination);
+                if (NULLPTR == exchanger) {
+                    return false;
+                }
+
+                ITransmissionPtr transmission = exchanger->GetTransmission();
+                if (NULLPTR == transmission) {
+                    return false;
+                }
+
+                app::protocol::ClampTcpMssIPv6(packet, packet_length, app::protocol::ComputeDynamicTcpMss(false, 80));
+
+                return SendIPv6PacketToClient(transmission, packet, packet_length);
+            }
+
+            bool VirtualEthernetSwitcher::OpenIPv6TransitIfNeed() noexcept {
+#if defined(_LINUX)
+                const auto& ipv6 = configuration_->server.ipv6;
+                ppp::string mode = ToLower(ipv6.mode);
+                bool enable_transit = ipv6.enabled && (mode == "nat" || mode == "prefix");
+                if (!enable_transit) {
+                    return true;
+                }
+
+                boost::system::error_code ec;
+                boost::asio::ip::address prefix = StringToAddress(ipv6.prefix, ec);
+                if (ec || !prefix.is_v6()) {
+                    return false;
+                }
+
+                boost::asio::ip::address_v6 transit = prefix.to_v6();
+                if (transit.is_unspecified()) {
+                    boost::asio::ip::address_v6::bytes_type bytes = {};
+                    bytes[0] = 0xfd;
+                    bytes[1] = 0x42;
+                    bytes[2] = 0x42;
+                    bytes[3] = 0x42;
+                    bytes[4] = 0x42;
+                    bytes[15] = 1;
+                    transit = boost::asio::ip::address_v6(bytes);
+                }
+
+                if (!ipv6.gateway.empty()) {
+                    ec.clear();
+                    boost::asio::ip::address configured_gateway = StringToAddress(ipv6.gateway, ec);
+                    if (!ec && configured_gateway.is_v6()) {
+                        transit = configured_gateway.to_v6();
+                    }
+                }
+                else {
+                    boost::asio::ip::address_v6::bytes_type bytes = transit.to_bytes();
+                    bytes[15] = 1;
+                    transit = boost::asio::ip::address_v6(bytes);
+                }
+
+                std::string transit_std = transit.to_string();
+                ppp::string transit_ip(transit_std.data(), transit_std.size());
+                int prefix_length = std::max<int>(64, std::min<int>(128, ipv6.prefix_length));
+
+                ppp::vector<ppp::string> no_dns;
+                ITapPtr tap = ppp::tap::ITap::Create(context_, "openppp2v6", "169.254.254.1", "169.254.254.2", "255.255.255.252", false, false, no_dns);
+                if (NULLPTR == tap || !tap->Open()) {
+                    return false;
+                }
+
+                bool address_ok = ppp::tap::TapLinux::SetIPv6Address(tap->GetId(), transit_ip, prefix_length);
+                DebugLog("server ipv6 transit address %s name=%s address=%s/%d", address_ok ? "ok" : "fail", tap->GetId().data(), transit_ip.data(), prefix_length);
+                if (!address_ok) {
+                    tap->Dispose();
+                    return false;
+                }
+
+                DebugLog("server ipv6 transit connected route managed by kernel name=%s prefix=%s/%d", tap->GetId().data(), ipv6.prefix.data(), prefix_length);
+
+                tap->PacketInput =
+                    [self = shared_from_this()](ppp::tap::ITap* sender, ppp::tap::ITap::PacketInputEventArgs& e) noexcept -> bool {
+                        if (NULLPTR == sender || NULLPTR == e.Packet || e.PacketLength < 40) {
+                            return false;
+                        }
+
+                        auto switcher = std::dynamic_pointer_cast<VirtualEthernetSwitcher>(self);
+                        if (NULLPTR == switcher) {
+                            return false;
+                        }
+
+                        return switcher->ReceiveIPv6TransitPacket(reinterpret_cast<Byte*>(e.Packet), e.PacketLength);
+                    };
+
+                ipv6_transit_tap_ = tap;
+                DebugLog("server ipv6 transit tap opened name=%s address=%s/%d", tap->GetId().data(), transit_ip.data(), prefix_length);
+#endif
                 return true;
             }
 
@@ -868,6 +1506,7 @@ namespace ppp {
                 std::shared_ptr<boost::asio::ip::udp::resolver> uresolver;
 
                 VirtualEthernetNamespaceCachePtr cache;
+                ITapPtr ipv6_transit_tap;
                 NatInformationTable nats;
                 VirtualEthernetLoggerPtr logger;
                 VirtualEthernetExchangerTable exchangers;
@@ -880,6 +1519,7 @@ namespace ppp {
                     CloseAllAcceptors();
 
                     cache = std::move(namespace_cache_);
+                    ipv6_transit_tap = std::move(ipv6_transit_tap_);
                     nats = std::move(nats_);
                     logger = std::move(logger_);
 
@@ -900,6 +1540,10 @@ namespace ppp {
 
                 Dictionary::ReleaseAllObjects(exchangers);
                 Dictionary::ReleaseAllObjects(connections);
+
+                if (NULLPTR != ipv6_transit_tap) {
+                    ipv6_transit_tap->Dispose();
+                }
 
                 if (NULLPTR != cache) {
                     cache->Clear();
@@ -1028,7 +1672,12 @@ namespace ppp {
 
                 bool bok = false;
                 if (NULLPTR != info) {
-                    bok = exchanger->DoInformation(transmission, *info, y);
+                    InformationEnvelope envelope = BuildInformationEnvelope(session_id, *info);
+                    DebugLog("server info send update session=%s json=%s",
+                        auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
+                        envelope.ExtendedJson.data());
+                    AddIPv6Exchanger(session_id, envelope.Extensions.AssignedIPv6Address);
+                    bok = exchanger->DoInformation(transmission, envelope, y);
                     if (bok) {
                         bok = info->Valid();
                     }

--- a/ppp/app/server/VirtualEthernetSwitcher.h
+++ b/ppp/app/server/VirtualEthernetSwitcher.h
@@ -11,7 +11,9 @@
 #include <ppp/configurations/AppConfiguration.h>
 #include <ppp/app/protocol/VirtualEthernetPacket.h>
 #include <ppp/app/protocol/VirtualEthernetLogger.h>
+#include <ppp/app/protocol/VirtualEthernetLinklayer.h>
 #include <ppp/app/protocol/VirtualEthernetInformation.h>
+#include <ppp/tap/ITap.h>
 
 namespace ppp {
     namespace app {
@@ -36,16 +38,20 @@ namespace ppp {
                 }                                                       NatInformation;
                 typedef std::shared_ptr<NatInformation>                 NatInformationPtr;
                 typedef std::unordered_map<uint32_t, NatInformationPtr> NatInformationTable;
+                typedef std::unordered_map<ppp::string, std::shared_ptr<class VirtualEthernetExchanger>> IPv6ExchangerTable;
                 typedef ppp::cryptography::Ciphertext                   Ciphertext;
                 typedef std::shared_ptr<Ciphertext>                     CiphertextPtr;
 
             public:
                 typedef ppp::app::protocol::VirtualEthernetInformation  VirtualEthernetInformation;
+                typedef ppp::app::protocol::VirtualEthernetInformationExtensions VirtualEthernetInformationExtensions;
+                typedef ppp::app::protocol::VirtualEthernetLinklayer::InformationEnvelope InformationEnvelope;
                 typedef std::shared_ptr<VirtualEthernetInformation>     VirtualEthernetInformationPtr;
                 typedef std::shared_ptr<VirtualEthernetExchanger>       VirtualEthernetExchangerPtr;
                 typedef ppp::unordered_map<Int128,
                     VirtualEthernetExchangerPtr>                        VirtualEthernetExchangerTable;
                 typedef std::shared_ptr<VirtualEthernetManagedServer>   VirtualEthernetManagedServerPtr;
+                typedef std::shared_ptr<ppp::tap::ITap>                 ITapPtr;
                 typedef ppp::app::protocol::VirtualEthernetLogger       VirtualEthernetLogger;
                 typedef std::shared_ptr<VirtualEthernetLogger>          VirtualEthernetLoggerPtr;
                 typedef ppp::configurations::AppConfiguration           AppConfiguration;
@@ -151,6 +157,7 @@ namespace ppp {
                 void                                                    TickAllExchangers(UInt64 now) noexcept;
                 void                                                    TickAllConnections(UInt64 now) noexcept;
                 bool                                                    OpenManagedServerIfNeed() noexcept;
+                bool                                                    OpenIPv6TransitIfNeed() noexcept;
 
             private:
                 VirtualEthernetStaticEchoAllocatedContextPtr            StaticEchoUnallocated(int allocated_id) noexcept;
@@ -170,10 +177,23 @@ namespace ppp {
                 bool                                                    LoopbackDatagramSocket() noexcept;
                 bool                                                    OpenLogger() noexcept;
                 bool                                                    FlowerArrangement(const ITransmissionPtr& transmission, YieldContext& y) noexcept;
+                InformationEnvelope                                     BuildInformationEnvelope(const Int128& session_id, const VirtualEthernetInformation& info) noexcept;
+                bool                                                    BuildInformationIPv6Extensions(const Int128& session_id, VirtualEthernetInformationExtensions& extensions) noexcept;
+                bool                                                    AddIPv6Exchanger(const Int128& session_id, const boost::asio::ip::address& ip) noexcept;
+                bool                                                    DeleteIPv6Exchanger(const Int128& session_id, const boost::asio::ip::address& ip) noexcept;
+                VirtualEthernetExchangerPtr                             FindIPv6Exchanger(const boost::asio::ip::address& ip) noexcept;
+                bool                                                    OpenIPv6NeighborProxyIfNeed() noexcept;
+                bool                                                    AddIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept;
+                bool                                                    DeleteIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept;
+                bool                                                    SyncNdppdNeighborProxy() noexcept;
+                bool                                                    AddIPv6TransitRoute(const boost::asio::ip::address& ip) noexcept;
+                bool                                                    DeleteIPv6TransitRoute(const boost::asio::ip::address& ip) noexcept;
+                bool                                                    SendIPv6TransitPacket(Byte* packet, int packet_length) noexcept;
+                bool                                                    ReceiveIPv6TransitPacket(Byte* packet, int packet_length) noexcept;
+                bool                                                    SendIPv6PacketToClient(const ITransmissionPtr& transmission, Byte* packet, int packet_length) noexcept;
                 bool                                                    DeleteNatInformation(VirtualEthernetExchanger* key, uint32_t ip) noexcept;
                 NatInformationPtr                                       FindNatInformation(uint32_t ip) noexcept;
                 NatInformationPtr                                       AddNatInformation(const std::shared_ptr<VirtualEthernetExchanger>& exchanger, uint32_t ip, uint32_t mask) noexcept;
-                
             private:
                 template <typename TTransmission>
                 typename std::enable_if<std::is_base_of<ITransmission, TTransmission>::value, std::shared_ptr<TTransmission>/**/>::type
@@ -200,6 +220,7 @@ namespace ppp {
 
                 VirtualEthernetLoggerPtr                                logger_;
                 NatInformationTable                                     nats_;
+                IPv6ExchangerTable                                      ipv6s_;
                 FirewallPtr                                             firewall_;
                 VirtualEthernetExchangerTable                           exchangers_;
                 TimerPtr                                                timeout_;
@@ -207,11 +228,12 @@ namespace ppp {
                 ContextPtr                                              context_;
                 boost::asio::ip::udp::endpoint                          dnsserverEP_;
                 boost::asio::ip::address                                interfaceIP_;
+                ppp::string                                             ipv6_neighbor_proxy_ifname_;
+                ITapPtr                                                 ipv6_transit_tap_;
                 VirtualEthernetNetworkTcpipConnectionTable              connections_;
                 ITransmissionStatisticsPtr                              statistics_;
                 VirtualEthernetManagedServerPtr                         managed_server_;
                 VirtualEthernetNamespaceCachePtr                        namespace_cache_;
-
                 boost::asio::ip::udp::socket                            static_echo_socket_;
                 int                                                     static_echo_bind_port_ = 0;
                 std::shared_ptr<Byte>                                   static_echo_buffers_;

--- a/ppp/configurations/AppConfiguration.cpp
+++ b/ppp/configurations/AppConfiguration.cpp
@@ -109,6 +109,18 @@ namespace ppp {
             config.server.mapping = true;
             config.server.backend = "";
             config.server.backend_key = "";
+            config.server.ipv6.enabled = false;
+            config.server.ipv6.mode = "";
+            config.server.ipv6.prefix = "";
+            config.server.ipv6.prefix_length = 64;
+            config.server.ipv6.routed_prefix = true;
+            config.server.ipv6.neighbor_proxy = false;
+            config.server.ipv6.neighbor_proxy_provider = "kernel";
+            config.server.ipv6.gateway = "";
+            config.server.ipv6.dns1 = "";
+            config.server.ipv6.dns2 = "";
+            config.server.ipv6.stable_secret = "";
+            config.server.ipv6.allocation = "guid-hash";
 
             config.client.mappings.clear();
             config.client.guid = StringAuxiliary::Int128ToGuidString(MAKE_OWORD(UINT64_MAX, UINT64_MAX));
@@ -146,6 +158,14 @@ namespace ppp {
                     &config.server.backend,
                     &config.server.backend_key,
                     &config.server.log,
+                    &config.server.ipv6.mode,
+                    &config.server.ipv6.prefix,
+                    &config.server.ipv6.gateway,
+                    &config.server.ipv6.dns1,
+                    &config.server.ipv6.dns2,
+                    &config.server.ipv6.stable_secret,
+                    &config.server.ipv6.neighbor_proxy_provider,
+                    &config.server.ipv6.allocation,
                     &config.client.guid,
                     &config.client.server,
                     &config.client.server_proxy,
@@ -276,6 +296,7 @@ namespace ppp {
             }
             
             config.server.node = std::max<int>(0, config.server.node);
+            config.server.ipv6.prefix_length = std::max<int>(0, std::min<int>(128, config.server.ipv6.prefix_length));
             config.udp.dns.ttl = std::max<int>(0, config.udp.dns.ttl);
 
             if (config.udp.dns.timeout < 1) {
@@ -384,6 +405,38 @@ namespace ppp {
                 }
                 else {
                     ip = Ipep::ToAddressString<ppp::string>(address);
+                }
+            }
+
+            ppp::string ipv6_mode = ToLower(config.server.ipv6.mode);
+            config.server.ipv6.mode = ipv6_mode;
+            if (config.server.ipv6.enabled) {
+                bool has_public_ipv6_plan = !config.server.ipv6.prefix.empty();
+                if (ipv6_mode.empty()) {
+                    config.server.ipv6.mode = has_public_ipv6_plan ? "prefix" : "nat";
+                }
+
+                if (config.server.ipv6.mode == "nat") {
+                    config.server.ipv6.routed_prefix = false;
+                    config.server.ipv6.neighbor_proxy = false;
+                    if (config.server.ipv6.prefix.empty()) {
+                        config.server.ipv6.prefix = "fd42:4242:4242::";
+                    }
+                    if (config.server.ipv6.prefix_length < 64) {
+                        config.server.ipv6.prefix_length = 64;
+                    }
+                }
+                elif(config.server.ipv6.mode == "prefix") {
+                    if (config.server.ipv6.prefix.empty()) {
+                        config.server.ipv6.mode = "nat";
+                        config.server.ipv6.routed_prefix = false;
+                        config.server.ipv6.neighbor_proxy = false;
+                        config.server.ipv6.prefix = "fd42:4242:4242::";
+                        config.server.ipv6.prefix_length = 64;
+                    }
+                }
+                else {
+                    config.server.ipv6.mode = has_public_ipv6_plan ? "prefix" : "nat";
                 }
             }
 
@@ -620,6 +673,25 @@ namespace ppp {
             return true;
         }
 
+        template <typename TValue>
+        static bool AssignIfPresent(TValue& destination, const Json::Value& json) noexcept {
+            if (json.isNull()) {
+                return false;
+            }
+
+            destination = JsonAuxiliary::AsValue<TValue>(json);
+            return true;
+        }
+
+        static bool AssignBoolIfPresent(bool& destination, const Json::Value& json) noexcept {
+            if (json.isNull()) {
+                return false;
+            }
+
+            destination = JsonAuxiliary::AsValue<bool>(json);
+            return true;
+        }
+
         static bool ReadJsonToRoute(AppConfiguration::RouteConfiguration& route, const Json::Value& json) noexcept {
             if (json.isNull()) {
                 return false;
@@ -711,13 +783,15 @@ namespace ppp {
             config.udp.listen.port = JsonAuxiliary::AsValue<int>(json["udp"]["listen"]["port"]);
             config.udp.cwnd = std::max<int>(0, JsonAuxiliary::AsValue<int>(json["udp"]["cwnd"]));
             config.udp.rwnd = std::max<int>(0, JsonAuxiliary::AsValue<int>(json["udp"]["rwnd"]));
-            config.udp.static_.dns = JsonAuxiliary::AsValue<bool>(json["udp"]["static"]["dns"]);
-            config.udp.static_.quic = JsonAuxiliary::AsValue<bool>(json["udp"]["static"]["quic"]);
-            config.udp.static_.icmp = JsonAuxiliary::AsValue<bool>(json["udp"]["static"]["icmp"]);
+            AssignBoolIfPresent(config.udp.static_.dns, json["udp"]["static"]["dns"]);
+            AssignBoolIfPresent(config.udp.static_.quic, json["udp"]["static"]["quic"]);
+            AssignBoolIfPresent(config.udp.static_.icmp, json["udp"]["static"]["icmp"]);
             config.udp.static_.aggligator = JsonAuxiliary::AsValue<int>(json["udp"]["static"]["aggligator"]);
             config.udp.static_.keep_alived[0] = JsonAuxiliary::AsValue<int>(json["udp"]["static"]["keep-alived"][0]);
             config.udp.static_.keep_alived[1] = JsonAuxiliary::AsValue<int>(json["udp"]["static"]["keep-alived"][1]);
-            ReadJsonAllAddressStringToSet(json["udp"]["static"]["servers"], config.udp.static_.servers);
+            if (!ReadJsonAllAddressStringToSet(json["udp"]["static"]["servers"], config.udp.static_.servers)) {
+                ReadJsonAllAddressStringToSet(json["udp"]["static"]["server"], config.udp.static_.servers);
+            }
 
             config.tcp.inactive.timeout = JsonAuxiliary::AsValue<int>(json["tcp"]["inactive"]["timeout"]);
             config.tcp.connect.timeout = JsonAuxiliary::AsValue<int>(json["tcp"]["connect"]["timeout"]);
@@ -743,7 +817,9 @@ namespace ppp {
             config.websocket.ssl.certificate_chain_file = JsonAuxiliary::AsValue<std::string>(json["websocket"]["ssl"]["certificate-chain-file"]);
             config.websocket.ssl.certificate_key_password = JsonAuxiliary::AsValue<std::string>(json["websocket"]["ssl"]["certificate-key-password"]);
             config.websocket.ssl.ciphersuites = JsonAuxiliary::AsValue<std::string>(json["websocket"]["ssl"]["ciphersuites"]);
-            config.websocket.ssl.verify_peer = JsonAuxiliary::AsValue<bool>(json["websocket"]["ssl"]["verify-peer"]);
+            if (!AssignBoolIfPresent(config.websocket.ssl.verify_peer, json["websocket"]["ssl"]["verify-peer"])) {
+                AssignBoolIfPresent(config.websocket.ssl.verify_peer, json["websocket"]["verify-peer"]);
+            }
             config.websocket.host = JsonAuxiliary::AsValue<ppp::string>(json["websocket"]["host"]);
             config.websocket.path = JsonAuxiliary::AsValue<ppp::string>(json["websocket"]["path"]);
             config.websocket.http.error = JsonAuxiliary::AsValue<ppp::string>(json["websocket"]["http"]["error"]);
@@ -760,17 +836,29 @@ namespace ppp {
             config.key.protocol_key = JsonAuxiliary::AsValue<ppp::string>(json["key"]["protocol-key"]);
             config.key.transport = JsonAuxiliary::AsValue<ppp::string>(json["key"]["transport"]);
             config.key.transport_key = JsonAuxiliary::AsValue<ppp::string>(json["key"]["transport-key"]);
-            config.key.masked = JsonAuxiliary::AsValue<bool>(json["key"]["masked"]);
-            config.key.plaintext = JsonAuxiliary::AsValue<bool>(json["key"]["plaintext"]);
-            config.key.delta_encode = JsonAuxiliary::AsValue<bool>(json["key"]["delta-encode"]);
-            config.key.shuffle_data = JsonAuxiliary::AsValue<bool>(json["key"]["shuffle-data"]);
+            AssignBoolIfPresent(config.key.masked, json["key"]["masked"]);
+            AssignBoolIfPresent(config.key.plaintext, json["key"]["plaintext"]);
+            AssignBoolIfPresent(config.key.delta_encode, json["key"]["delta-encode"]);
+            AssignBoolIfPresent(config.key.shuffle_data, json["key"]["shuffle-data"]);
 
             config.server.log = JsonAuxiliary::AsValue<ppp::string>(json["server"]["log"]);
             config.server.node = JsonAuxiliary::AsValue<int>(json["server"]["node"]);
-            config.server.subnet = JsonAuxiliary::AsValue<bool>(json["server"]["subnet"]);
-            config.server.mapping = JsonAuxiliary::AsValue<bool>(json["server"]["mapping"]);
+            AssignBoolIfPresent(config.server.subnet, json["server"]["subnet"]);
+            AssignBoolIfPresent(config.server.mapping, json["server"]["mapping"]);
             config.server.backend = JsonAuxiliary::AsValue<ppp::string>(json["server"]["backend"]);
             config.server.backend_key = JsonAuxiliary::AsValue<ppp::string>(json["server"]["backend-key"]);
+            AssignBoolIfPresent(config.server.ipv6.enabled, json["server"]["ipv6"]["enabled"]);
+            AssignIfPresent(config.server.ipv6.mode, json["server"]["ipv6"]["mode"]);
+            AssignIfPresent(config.server.ipv6.prefix, json["server"]["ipv6"]["prefix"]);
+            AssignIfPresent(config.server.ipv6.prefix_length, json["server"]["ipv6"]["prefix-length"]);
+            AssignBoolIfPresent(config.server.ipv6.routed_prefix, json["server"]["ipv6"]["routed-prefix"]);
+            AssignBoolIfPresent(config.server.ipv6.neighbor_proxy, json["server"]["ipv6"]["neighbor-proxy"]);
+            AssignIfPresent(config.server.ipv6.neighbor_proxy_provider, json["server"]["ipv6"]["neighbor-proxy-provider"]);
+            AssignIfPresent(config.server.ipv6.gateway, json["server"]["ipv6"]["gateway"]);
+            AssignIfPresent(config.server.ipv6.dns1, json["server"]["ipv6"]["dns1"]);
+            AssignIfPresent(config.server.ipv6.dns2, json["server"]["ipv6"]["dns2"]);
+            AssignIfPresent(config.server.ipv6.stable_secret, json["server"]["ipv6"]["stable-secret"]);
+            AssignIfPresent(config.server.ipv6.allocation, json["server"]["ipv6"]["allocation"]);
 
             LoadAllMappings(config, json["client"]["mappings"]);
             LoadAllRoutes(config.client.routes, json["client"]["routes"]);
@@ -787,7 +875,7 @@ namespace ppp {
             config.client.socks_proxy.username = JsonAuxiliary::AsValue<ppp::string>(json["client"]["socks-proxy"]["username"]);
             config.client.socks_proxy.password = JsonAuxiliary::AsValue<ppp::string>(json["client"]["socks-proxy"]["password"]);
 #if defined(_WIN32)
-            config.client.paper_airplane.tcp = JsonAuxiliary::AsValue<bool>(json["client"]["paper-airplane"]["tcp"]);
+            AssignBoolIfPresent(config.client.paper_airplane.tcp, json["client"]["paper-airplane"]["tcp"]);
 #endif
             return Loaded();
         }
@@ -851,6 +939,7 @@ namespace ppp {
                 }
             }
 
+            udp["static"]["servers"] = servers;
             udp["static"]["server"] = servers;
             udp["static"]["dns"] = config.udp.static_.dns;
             udp["static"]["quic"] = config.udp.static_.quic;
@@ -895,6 +984,7 @@ namespace ppp {
             websocket["ssl"]["certificate-key-password"] = stl::transform<ppp::string>(config.websocket.ssl.certificate_key_password);
             websocket["ssl"]["ciphersuites"] = stl::transform<ppp::string>(config.websocket.ssl.ciphersuites);
             websocket["ssl"]["verify-peer"] = config.websocket.ssl.verify_peer;
+            websocket["verify-peer"] = config.websocket.ssl.verify_peer;
             websocket["http"]["error"] = stl::transform<ppp::string>(config.websocket.http.error);
 
             // Set websocket structure
@@ -939,6 +1029,18 @@ namespace ppp {
             server["mapping"] = config.server.mapping;
             server["backend"] = config.server.backend; /* ws://192.168.0.24/ppp/webhook */
             server["backend-key"] = config.server.backend_key;
+            server["ipv6"]["enabled"] = config.server.ipv6.enabled;
+            server["ipv6"]["mode"] = config.server.ipv6.mode;
+            server["ipv6"]["prefix"] = config.server.ipv6.prefix;
+            server["ipv6"]["prefix-length"] = config.server.ipv6.prefix_length;
+            server["ipv6"]["routed-prefix"] = config.server.ipv6.routed_prefix;
+            server["ipv6"]["neighbor-proxy"] = config.server.ipv6.neighbor_proxy;
+            server["ipv6"]["neighbor-proxy-provider"] = config.server.ipv6.neighbor_proxy_provider;
+            server["ipv6"]["gateway"] = config.server.ipv6.gateway;
+            server["ipv6"]["dns1"] = config.server.ipv6.dns1;
+            server["ipv6"]["dns2"] = config.server.ipv6.dns2;
+            server["ipv6"]["stable-secret"] = config.server.ipv6.stable_secret;
+            server["ipv6"]["allocation"] = config.server.ipv6.allocation;
             root["server"] = server;
 
             // Set client structure

--- a/ppp/configurations/AppConfiguration.h
+++ b/ppp/configurations/AppConfiguration.h
@@ -132,6 +132,20 @@ namespace ppp {
                 bool                                                        mapping;
                 ppp::string                                                 backend;
                 ppp::string                                                 backend_key;
+                struct {
+                    bool                                                    enabled;
+                    ppp::string                                             mode;
+                    ppp::string                                             prefix;
+                    int                                                     prefix_length;
+                    bool                                                    routed_prefix;
+                    bool                                                    neighbor_proxy;
+                    ppp::string                                             neighbor_proxy_provider;
+                    ppp::string                                             gateway;
+                    ppp::string                                             dns1;
+                    ppp::string                                             dns2;
+                    ppp::string                                             stable_secret;
+                    ppp::string                                             allocation;
+                }                                                           ipv6;
             }                                                               server;
             struct {
                 ppp::string                                                 guid;

--- a/ppp/ethernet/VEthernet.cpp
+++ b/ppp/ethernet/VEthernet.cpp
@@ -402,7 +402,7 @@ namespace ppp
                     struct ip_hdr* iphdr = ip_hdr::Parse(e.Packet, packet_length);
                     if (NULLPTR == iphdr) // INVALID IS (Destination & Mask) != Destination;
                     {
-                        return false;
+                        return OnPacketInput((Byte*)e.Packet, packet_length, vnet_);
                     }
 #if !defined(_WIN32)
                     elif(mta_)
@@ -760,6 +760,11 @@ namespace ppp
         }
 
         bool VEthernet::OnPacketInput(ppp::net::native::ip_hdr* packet, int packet_length, int header_length, int proto, bool vnet) noexcept
+        {
+            return false;
+        }
+
+        bool VEthernet::OnPacketInput(Byte* packet, int packet_length, bool vnet) noexcept
         {
             return false;
         }

--- a/ppp/ethernet/VEthernet.h
+++ b/ppp/ethernet/VEthernet.h
@@ -66,10 +66,11 @@ namespace ppp
             virtual std::shared_ptr<VNetstack>                              NewNetstack() noexcept = 0;
 
         protected:
-            virtual bool                                                    OnTick(uint64_t now) noexcept;
-            virtual bool                                                    OnUpdate(uint64_t now) noexcept;
-            virtual bool                                                    OnPacketInput(const std::shared_ptr<IPFrame>& packet) noexcept;
-            virtual bool                                                    OnPacketInput(ppp::net::native::ip_hdr* packet, int packet_length, int header_length, int proto, bool vnet) noexcept;
+                virtual bool                                                    OnTick(uint64_t now) noexcept;
+                virtual bool                                                    OnUpdate(uint64_t now) noexcept;
+                virtual bool                                                    OnPacketInput(const std::shared_ptr<IPFrame>& packet) noexcept;
+                virtual bool                                                    OnPacketInput(ppp::net::native::ip_hdr* packet, int packet_length, int header_length, int proto, bool vnet) noexcept;
+                virtual bool                                                    OnPacketInput(Byte* packet, int packet_length, bool vnet) noexcept;
 
         private:
             void                                                            Finalize() noexcept;

--- a/windows/ppp/win32/network/NetworkInterface.cpp
+++ b/windows/ppp/win32/network/NetworkInterface.cpp
@@ -1248,6 +1248,116 @@ namespace ppp
                 return dwExitCode == ERROR_SUCCESS;
             }
 
+            static bool ExecuteNetshCommand(const ppp::string& command_line) noexcept {
+                if (command_line.empty()) {
+                    return false;
+                }
+
+                PROCESS_INFORMATION pi;
+                ZeroMemory(&pi, sizeof(pi));
+
+                STARTUPINFOA si;
+                ZeroMemory(&si, sizeof(si));
+                si.cb = sizeof(si);
+
+                char command[1200];
+                strncpy(command, command_line.data(), sizeof(command) - 1);
+                command[sizeof(command) - 1] = '\0';
+
+                if (!CreateProcessA(NULLPTR, command, NULLPTR, NULLPTR, FALSE, CREATE_NO_WINDOW, NULLPTR, NULLPTR, &si, &pi)) {
+                    return false;
+                }
+
+                DWORD dwExitCode = INFINITE;
+                if (WaitForSingleObject(pi.hProcess, INFINITE) == WAIT_OBJECT_0) {
+                    if (!GetExitCodeProcess(pi.hProcess, &dwExitCode)) {
+                        dwExitCode = INFINITE;
+                    }
+                }
+
+                CloseHandle(pi.hProcess);
+                CloseHandle(pi.hThread);
+                return dwExitCode == ERROR_SUCCESS;
+            }
+
+            bool SetIPv6Address(int interface_index, const ppp::string& ip, int prefix_length) noexcept {
+                ppp::string interface_name = GetInterfaceName(interface_index);
+                if (interface_name.empty() || ip.empty()) {
+                    return false;
+                }
+
+                char command[1200];
+                snprintf(command, sizeof(command), "netsh interface ipv6 set address interface=\"%s\" address=%s/%d", interface_name.data(), ip.data(), prefix_length);
+                return ExecuteNetshCommand(command);
+            }
+
+            bool DeleteIPv6Address(int interface_index, const ppp::string& ip) noexcept {
+                ppp::string interface_name = GetInterfaceName(interface_index);
+                if (interface_name.empty() || ip.empty()) {
+                    return false;
+                }
+
+                char command[1200];
+                snprintf(command, sizeof(command), "netsh interface ipv6 delete address interface=\"%s\" address=%s", interface_name.data(), ip.data());
+                return ExecuteNetshCommand(command);
+            }
+
+            bool SetIPv6DefaultGateway(int interface_index, const ppp::string& gateway, int metric) noexcept {
+                ppp::string interface_name = GetInterfaceName(interface_index);
+                if (interface_name.empty() || gateway.empty()) {
+                    return false;
+                }
+
+                char command[1200];
+                snprintf(command, sizeof(command), "netsh interface ipv6 add route ::/0 interface=\"%s\" nexthop=%s metric=%d store=active", interface_name.data(), gateway.data(), std::max<int>(1, metric));
+                return ExecuteNetshCommand(command);
+            }
+
+            bool DeleteIPv6DefaultGateway(int interface_index) noexcept {
+                ppp::string interface_name = GetInterfaceName(interface_index);
+                if (interface_name.empty()) {
+                    return false;
+                }
+
+                char command[1200];
+                snprintf(command, sizeof(command), "netsh interface ipv6 delete route ::/0 interface=\"%s\" store=active", interface_name.data());
+                return ExecuteNetshCommand(command);
+            }
+
+            bool SetDnsAddressesV6(int interface_index, const ppp::vector<ppp::string>& servers) noexcept {
+                ppp::string interface_name = GetInterfaceName(interface_index);
+                if (interface_name.empty()) {
+                    return false;
+                }
+
+                if (servers.empty()) {
+                    char command[1200];
+                    snprintf(command, sizeof(command), "netsh interface ipv6 delete dnsservers name=\"%s\" all validate=no", interface_name.data());
+                    return ExecuteNetshCommand(command);
+                }
+
+                bool any = false;
+                int index = 1;
+                for (const ppp::string& server : servers) {
+                    if (server.empty()) {
+                        continue;
+                    }
+
+                    char command[1200];
+                    if (index == 1) {
+                        snprintf(command, sizeof(command), "netsh interface ipv6 set dnsservers name=\"%s\" static %s primary validate=no", interface_name.data(), server.data());
+                    }
+                    else {
+                        snprintf(command, sizeof(command), "netsh interface ipv6 add dnsservers name=\"%s\" %s index=%d validate=no", interface_name.data(), server.data(), index);
+                    }
+
+                    any |= ExecuteNetshCommand(command);
+                    index++;
+                }
+
+                return any;
+            }
+
             static bool FixGatewayServerAddress(const ppp::win32::network::AdapterInterfacePtr& ai) noexcept
             {
                 boost::system::error_code ec;

--- a/windows/ppp/win32/network/NetworkInterface.h
+++ b/windows/ppp/win32/network/NetworkInterface.h
@@ -27,23 +27,23 @@ namespace ppp
 
             typedef struct
             {
-                ppp::string                                     Driver;                 // Çı¶¯
+                ppp::string                                     Driver;                 // é©±åŠ¨
                 ppp::string                                     Guid;                   // GUID
-                ppp::string                                     MacAddress;             // MACµØÖ·
-                int                                             Index;                  // Ë÷Òı
-                int                                             InterfaceIndex;         // Íø¿¨Ë÷Òı
-                ppp::vector<ppp::string>                        IPSubnet;               // ×ÓÍø    
-                ppp::vector<ppp::string>                        DnsAddresses;           // DNS·şÎñÆ÷
-                ppp::vector<ppp::string>                        IPAddresses;            // IPµØÖ·
-                ppp::vector<ppp::string>                        DefaultIPGateway;       // Ä¬ÈÏÍø¹Ø·şÎñÆ÷
-                bool                                            DhcpEnabled;            // ÆôÓÃDHCP
-                int                                             Metric;                 // Ô¾µã
-                bool                                            IPEnabled;              // IPÆôÓÃ
-                ppp::string                                     ConnectionId;           // Á´½ÓID
-                ppp::string                                     ScopeId;                // ÓòID
-                ppp::string                                     Caption;                // ±êÌâ
-                ppp::string                                     Description;            // ÃèÊöĞÅÏ¢
-                OperationalStatus                               Status;                 // ²Ù×÷×´Ì¬
+                ppp::string                                     MacAddress;             // MACåœ°å€
+                int                                             Index;                  // ç´¢å¼•
+                int                                             InterfaceIndex;         // æ¥å£ç´¢å¼•
+                ppp::vector<ppp::string>                        IPSubnet;               // IPå­ç½‘
+                ppp::vector<ppp::string>                        DnsAddresses;           // DNSæœåŠ¡å™¨
+                ppp::vector<ppp::string>                        IPAddresses;            // IPåœ°å€
+                ppp::vector<ppp::string>                        DefaultIPGateway;       // é»˜è®¤IPç½‘å…³
+                bool                                            DhcpEnabled;            // å¯ç”¨DHCP
+                int                                             Metric;                 // åº¦é‡å€¼
+                bool                                            IPEnabled;              // IPå¯ç”¨
+                ppp::string                                     ConnectionId;           // è¿æ¥ID
+                ppp::string                                     ScopeId;                // ä½œç”¨åŸŸID
+                ppp::string                                     Caption;                // æ ‡é¢˜
+                ppp::string                                     Description;            // æè¿°ä¿¡æ¯
+                OperationalStatus                               Status;                 // è¿è¡ŒçŠ¶æ€
             } NetworkInterface;
 
             typedef struct
@@ -67,9 +67,14 @@ namespace ppp
 
             bool                                                SetInterfaceName(int interface_index, const ppp::string& interface_name) noexcept;
             bool                                                SetDnsAddresses(int interface_index, const ppp::vector<ppp::string>& servers) noexcept;
+            bool                                                SetDnsAddressesV6(int interface_index, const ppp::vector<ppp::string>& servers) noexcept;
             bool                                                SetDefaultIPGateway(int interface_index, const ppp::vector<ppp::string>& servers) noexcept;
             bool                                                SetDefaultIPGateway(int interface_index, const ppp::vector<boost::asio::ip::address>& servers) noexcept;
             bool                                                SetIPAddresses(const ppp::string& interface_name, const ppp::string& ip, const ppp::string& mask) noexcept;
+            bool                                                SetIPv6Address(int interface_index, const ppp::string& ip, int prefix_length) noexcept;
+            bool                                                DeleteIPv6Address(int interface_index, const ppp::string& ip) noexcept;
+            bool                                                SetIPv6DefaultGateway(int interface_index, const ppp::string& gateway, int metric) noexcept;
+            bool                                                DeleteIPv6DefaultGateway(int interface_index) noexcept;
             bool                                                SetIPAddresses(int interface_index, const ppp::vector<ppp::string>& ips, const ppp::vector<ppp::string>& masks) noexcept;
             bool                                                DhcpEnabled(int interface_index) noexcept;
             bool                                                ResetNetworkEnvironment() noexcept;


### PR DESCRIPTION
## Summary
- deliver assigned IPv6 settings from the server to the client through the existing VirtualEthernet information channel
- apply assigned IPv6 address, gateway, DNS, and route handling on the client, and add Linux-side IPv6 transit routing support on the server
- show assigned IPv6 details in runtime status output so IPv6 session state is visible during operation
## Details
This change adds an IPv6 control-plane path for VPN sessions.
On the server side, IPv6 session information is built and attached to the existing `INFO` message flow. The assigned payload can include mode, address, prefix length, gateway, DNS, and related flags. Linux transit handling is also extended so assigned IPv6 endpoints can be routed to the tunnel correctly.
On the client side, the assigned IPv6 information is received from the server and applied to the tunnel interface. This includes:
- IPv6 address assignment
- default route or gateway handling where applicable
- IPv6 DNS configuration
- cleanup/restoration when the session changes or closes
The runtime status output is also extended to print assigned IPv6 details, which makes IPv6 behavior easier to verify during testing.
## Scope
This PR is intended to stay focused on IPv6 delivery and runtime behavior:
- IPv6 information transport
- client IPv6 application
- server IPv6 transit support
- runtime IPv6 visibility
It does not intentionally change VMUX, AGG, or port-mapping feature behavior.
## Validation
- built successfully on the prepared PR branch with CMake
- verified that the PR branch includes runtime status output for assigned IPv6 fields