### PR TITLE
完善 IPv6 NAT 路由与转发，并收敛服务端 TUN/邻居代理管理逻辑

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -87,6 +87,100 @@ static constexpr int PPP_VIRR_UPDATE_STRETCH  = 300;    // Retry interval in sec
 static constexpr int PPP_VIRR_UPDATE_INTERVAL = 86400;  // Daily update interval in seconds
 static constexpr int PPP_VBGP_UPDATE_INTERVAL = 3600;   // Hourly vBGP update interval
 
+#if defined(_LINUX)
+static bool LinuxExecuteCommand(const ppp::string& command) noexcept
+{
+    if (command.empty())
+    {
+        return false;
+    }
+
+    int status = system(command.data());
+    return status == 0;
+}
+
+static int LinuxExecuteCommandWithStatus(const ppp::string& command) noexcept
+{
+    if (command.empty())
+    {
+        return -1;
+    }
+
+    return system(command.data());
+}
+
+static bool LinuxPrepareIpv6NatEnvironment(const std::shared_ptr<AppConfiguration>& configuration) noexcept
+{
+    if (NULLPTR == configuration)
+    {
+        return false;
+    }
+
+    const auto& ipv6 = configuration->server.ipv6;
+    if (!ipv6.enabled || ToLower(ipv6.mode) != "nat")
+    {
+        return true;
+    }
+
+    ppp::string prefix = ipv6.prefix;
+    if (prefix.empty())
+    {
+        prefix = "fd42:4242:4242::";
+    }
+
+    int prefix_length = std::max<int>(64, std::min<int>(128, ipv6.prefix_length));
+    char sysctl_command[256];
+    snprintf(sysctl_command, sizeof(sysctl_command), "sysctl -w net.ipv6.conf.all.forwarding=1 > /dev/null 2>&1");
+    if (!LinuxExecuteCommand(sysctl_command))
+    {
+        fprintf(stdout, "Linux IPv6 NAT prepare failed: cannot enable ipv6 forwarding.\r\n");
+        return false;
+    }
+    char nft_flush_command[256];
+    snprintf(nft_flush_command, sizeof(nft_flush_command), "nft list table ip6 openppp2 >/dev/null 2>&1 && nft flush table ip6 openppp2 >/dev/null 2>&1 || true");
+    LinuxExecuteCommand(nft_flush_command);
+
+    char nft_command[2048];
+    snprintf(nft_command, sizeof(nft_command),
+        "nft add table ip6 openppp2 >/dev/null 2>&1; "
+        "nft 'add chain ip6 openppp2 forward { type filter hook forward priority filter; policy accept; }' >/dev/null 2>&1; "
+        "nft 'add chain ip6 openppp2 postrouting { type nat hook postrouting priority srcnat; policy accept; }' >/dev/null 2>&1; "
+        "nft 'add rule ip6 openppp2 forward ip6 saddr %s/%d accept' >/dev/null 2>&1; "
+        "nft 'add rule ip6 openppp2 forward ip6 daddr %s/%d ct state related,established accept' >/dev/null 2>&1; "
+        "nft 'add rule ip6 openppp2 postrouting ip6 saddr %s/%d masquerade' >/dev/null 2>&1",
+        prefix.data(), prefix_length,
+        prefix.data(), prefix_length,
+        prefix.data(), prefix_length);
+
+    if (LinuxExecuteCommand(nft_command))
+    {
+        return true;
+    }
+
+    char ip6tables_command[2048];
+    snprintf(ip6tables_command, sizeof(ip6tables_command),
+        "ip6tables -C FORWARD -s %s/%d -j ACCEPT >/dev/null 2>&1 || "
+        "ip6tables -A FORWARD -s %s/%d -j ACCEPT >/dev/null 2>&1; "
+        "ip6tables -C FORWARD -d %s/%d -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT >/dev/null 2>&1 || "
+        "ip6tables -A FORWARD -d %s/%d -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT >/dev/null 2>&1; "
+        "ip6tables -t nat -C POSTROUTING -s %s/%d -j MASQUERADE >/dev/null 2>&1 || "
+        "ip6tables -t nat -A POSTROUTING -s %s/%d -j MASQUERADE >/dev/null 2>&1",
+        prefix.data(), prefix_length,
+        prefix.data(), prefix_length,
+        prefix.data(), prefix_length,
+        prefix.data(), prefix_length,
+        prefix.data(), prefix_length, prefix.data(), prefix_length);
+    int ip6tables_status = LinuxExecuteCommandWithStatus(ip6tables_command);
+    if (ip6tables_status == 0)
+    {
+        return true;
+    }
+
+    fprintf(stdout, "Linux IPv6 NAT prepare failed: nft and ip6tables rules both failed.\r\n");
+    return false;
+}
+#endif
+
 // Network interface configuration structure
 struct NetworkInterface final
 {
@@ -1228,6 +1322,14 @@ bool PppApplication::PreparedLoopbackEnvironment(const std::shared_ptr<NetworkIn
         std::shared_ptr<VirtualEthernetSwitcher> ethernet = NULLPTR;
         do
         {
+#if defined(_LINUX)
+            if (!LinuxPrepareIpv6NatEnvironment(configuration))
+            {
+                fprintf(stdout, "%s\r\n", "Failed to prepare Linux IPv6 NAT environment.");
+                break;
+            }
+#endif
+
             // Create server switcher
             ethernet = ppp::make_shared_object<VirtualEthernetSwitcher>(configuration);
             if (NULLPTR == ethernet)

--- a/main.cpp
+++ b/main.cpp
@@ -1331,7 +1331,7 @@ bool PppApplication::PreparedLoopbackEnvironment(const std::shared_ptr<NetworkIn
 #endif
 
             // Create server switcher
-            ethernet = ppp::make_shared_object<VirtualEthernetSwitcher>(configuration);
+            ethernet = ppp::make_shared_object<VirtualEthernetSwitcher>(configuration, network_interface->ComponentId);
             if (NULLPTR == ethernet)
             {
                 break;

--- a/ppp/app/client/VEthernetNetworkSwitcher.cpp
+++ b/ppp/app/client/VEthernetNetworkSwitcher.cpp
@@ -718,11 +718,20 @@ namespace ppp {
                         }
                     }
 #else
-                    // macOS: use route command to add IPv6 default route
-                    char cmd[600];
-                    snprintf(cmd, sizeof(cmd), "route -n add -inet6 default %s", gw_str.data());
-                    system(cmd);
-                    applied = true;
+                    if (MacosSetIPv6Route(tun_ni->Name, "::", 0, gw_str)) {
+                        applied = true;
+                    }
+#endif
+                }
+                else if (!ipv6_default_route_handled && extensions.AssignedIPv6Mode == VirtualEthernetInformationExtensions::IPv6Mode_Nat) {
+#if defined(_WIN32)
+                    if (ppp::win32::network::SetIPv6DefaultRoute(tun_ni->Index, 0)) {
+                        applied = true;
+                    }
+#elif defined(_MACOS)
+                    if (MacosSetIPv6Route(tun_ni->Name, "::", 0, ppp::string())) {
+                        applied = true;
+                    }
 #endif
                 }
 
@@ -818,10 +827,7 @@ namespace ppp {
                         ppp::tap::TapLinux::DeleteRoute6(tun_ni->Name, "::", 0, gw_str);
                     }
 #else
-                    // macOS: delete IPv6 default route
-                    char cmd[600];
-                    snprintf(cmd, sizeof(cmd), "route -n delete -inet6 default %s", gw_str.data());
-                    system(cmd);
+                    MacosDeleteIPv6Route(tun_ni->Name, "::", 0, gw_str);
 #endif
                 }
 
@@ -846,7 +852,11 @@ namespace ppp {
 #endif
                 }
                 else if (ext.AssignedIPv6Mode == VirtualEthernetInformationExtensions::IPv6Mode_Nat) {
-#if defined(_LINUX)
+#if defined(_WIN32)
+                    ppp::win32::network::DeleteIPv6DefaultGateway(tun_ni->Index);
+#elif defined(_MACOS)
+                    MacosDeleteIPv6Route(tun_ni->Name, "::", 0, ppp::string());
+#elif defined(_LINUX)
                     ppp::tap::TapLinux* linux_tap = dynamic_cast<ppp::tap::TapLinux*>(tap.get());
                     if (NULLPTR != linux_tap) {
                         ppp::tap::TapLinux::DeleteRoute6(tun_ni->Name, "::", 0, ppp::string());

--- a/ppp/app/server/VirtualEthernetSwitcher.cpp
+++ b/ppp/app/server/VirtualEthernetSwitcher.cpp
@@ -48,10 +48,11 @@ namespace ppp {
 
     namespace app {
         namespace server {
-            VirtualEthernetSwitcher::VirtualEthernetSwitcher(const AppConfigurationPtr& configuration) noexcept
+            VirtualEthernetSwitcher::VirtualEthernetSwitcher(const AppConfigurationPtr& configuration, const ppp::string& tun_name) noexcept
                 : disposed_(false)
                 , configuration_(configuration)
                 , context_(Executors::GetDefault())
+                , tun_name_(tun_name)
                 , static_echo_socket_(*context_)
                 , static_echo_bind_port_(IPEndPoint::MinPort) {
                 
@@ -252,7 +253,7 @@ namespace ppp {
                         auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
                         ipv6.routed_prefix ? "yes" : "no",
                         ipv6.neighbor_proxy ? "yes" : "no",
-                        ipv6.neighbor_proxy_provider.empty() ? "kernel" : ipv6.neighbor_proxy_provider.data(),
+                        "kernel",
                         (unsigned)extensions.AssignedIPv6PrefixLength);
                 }
 
@@ -272,7 +273,6 @@ namespace ppp {
                     return false;
                 }
 
-                bool need_ndppd_sync = false;
                 {
                     SynchronizedObjectScope scope(syncobj_);
                     for (auto tail = ipv6s_.begin(); tail != ipv6s_.end();) {
@@ -287,10 +287,6 @@ namespace ppp {
                     ipv6s_[ip_key] = exchanger;
                     AddIPv6TransitRoute(ip);
                     AddIPv6NeighborProxy(ip);
-                    need_ndppd_sync = false;
-                }
-                if (need_ndppd_sync) {
-                    SyncNdppdNeighborProxy();
                 }
                 return true;
             }
@@ -303,7 +299,6 @@ namespace ppp {
                 std::string ip_std = ip.to_string();
                 ppp::string ip_key(ip_std.data(), ip_std.size());
 
-                bool need_ndppd_sync = false;
                 {
                     SynchronizedObjectScope scope(syncobj_);
                     auto tail = ipv6s_.find(ip_key);
@@ -318,10 +313,6 @@ namespace ppp {
                     DeleteIPv6TransitRoute(ip);
                     DeleteIPv6NeighborProxy(ip);
                     ipv6s_.erase(tail);
-                    need_ndppd_sync = false;
-                }
-                if (need_ndppd_sync) {
-                    SyncNdppdNeighborProxy();
                 }
                 return true;
             }
@@ -346,27 +337,6 @@ namespace ppp {
                     return true;
                 }
 
-                ppp::string provider = ToLower(ipv6.neighbor_proxy_provider);
-                if (provider.empty()) {
-                    provider = "kernel";
-                }
-
-                DebugLog("server ipv6 neighbor proxy provider=%s", provider.data());
-                if (provider == "ndppd") {
-                    DebugLog("server ipv6 ndppd provider is externally managed; skip in-process config generation");
-                    return true;
-                }
-
-                if (provider == "manual" || provider == "external") {
-                    DebugLog("server ipv6 neighbor proxy provider=%s externally managed; skip in-process setup", provider.data());
-                    return true;
-                }
-
-                if (provider != "kernel") {
-                    DebugLog("server ipv6 neighbor proxy provider=%s not yet implemented in-process", provider.data());
-                    return true;
-                }
-
                 ppp::string uplink_name;
                 UInt32 address = 0;
                 UInt32 mask = 0;
@@ -381,65 +351,6 @@ namespace ppp {
 
                 ipv6_neighbor_proxy_ifname_ = uplink_name;
                 DebugLog("server ipv6 neighbor proxy enabled if=%s", uplink_name.data());
-#endif
-                return true;
-            }
-
-            bool VirtualEthernetSwitcher::SyncNdppdNeighborProxy() noexcept {
-#if defined(_LINUX)
-                const auto& ipv6 = configuration_->server.ipv6;
-                if (!ipv6.enabled || ToLower(ipv6.mode) != "prefix" || !ipv6.neighbor_proxy) {
-                    return true;
-                }
-
-                ppp::string uplink_name;
-                UInt32 address = 0;
-                UInt32 mask = 0;
-                UInt32 gw = 0;
-                if (!ppp::tap::TapLinux::GetPreferredNetworkInterface(uplink_name, address, mask, gw, ppp::string())) {
-                    return false;
-                }
-
-                ppp::string config_path = "/tmp/openppp2-ndppd.conf";
-                ppp::string config_text = "proxy ";
-                config_text += uplink_name;
-                config_text += " {\n";
-
-                int rules = 0;
-                {
-                    SynchronizedObjectScope scope(syncobj_);
-                    for (const auto& [ip_key, exchanger] : ipv6s_) {
-                        if (NULLPTR == exchanger) {
-                            continue;
-                        }
-
-                        config_text += "  rule ";
-                        config_text += ip_key;
-                        config_text += "/128 {\n";
-                        config_text += "    static\n";
-                        config_text += "  }\n";
-                        rules++;
-                    }
-                }
-
-                if (rules < 1) {
-                    config_text += "  rule ";
-                    config_text += ipv6.prefix;
-                    config_text += "/";
-                    config_text += stl::to_string<ppp::string>(ipv6.prefix_length);
-                    config_text += " {\n";
-                    config_text += "    static\n";
-                    config_text += "  }\n";
-                }
-
-                config_text += "}\n";
-
-                if (!ppp::io::File::WriteAllBytes(config_path.data(), config_text.data(), static_cast<int>(config_text.size()))) {
-                    return false;
-                }
-
-                DebugLog("server ipv6 ndppd config synced path=%s uplink=%s rules=%d", config_path.data(), uplink_name.data(), rules);
-                DebugLog("server ipv6 ndppd reload required path=%s", config_path.data());
 #endif
                 return true;
             }
@@ -1113,7 +1024,12 @@ namespace ppp {
                 int prefix_length = std::max<int>(64, std::min<int>(128, ipv6.prefix_length));
 
                 ppp::vector<ppp::string> no_dns;
-                ITapPtr tap = ppp::tap::ITap::Create(context_, "openppp2v6", "169.254.254.1", "169.254.254.2", "255.255.255.252", false, false, no_dns);
+                ppp::string tun_name = tun_name_;
+                if (tun_name.empty()) {
+                    tun_name = "ppp";
+                }
+
+                ITapPtr tap = ppp::tap::ITap::Create(context_, tun_name, "169.254.254.1", "169.254.254.2", "255.255.255.252", false, false, no_dns);
                 if (NULLPTR == tap || !tap->Open()) {
                     return false;
                 }

--- a/ppp/app/server/VirtualEthernetSwitcher.h
+++ b/ppp/app/server/VirtualEthernetSwitcher.h
@@ -87,7 +87,7 @@ namespace ppp {
                 typedef std::shared_ptr<VirtualEthernetNamespaceCache>  VirtualEthernetNamespaceCachePtr;
 
             public:
-                VirtualEthernetSwitcher(const AppConfigurationPtr& configuration) noexcept;
+                VirtualEthernetSwitcher(const AppConfigurationPtr& configuration, const ppp::string& tun_name = ppp::string()) noexcept;
                 virtual ~VirtualEthernetSwitcher() noexcept;
 
             public:
@@ -185,7 +185,6 @@ namespace ppp {
                 bool                                                    OpenIPv6NeighborProxyIfNeed() noexcept;
                 bool                                                    AddIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept;
                 bool                                                    DeleteIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept;
-                bool                                                    SyncNdppdNeighborProxy() noexcept;
                 bool                                                    AddIPv6TransitRoute(const boost::asio::ip::address& ip) noexcept;
                 bool                                                    DeleteIPv6TransitRoute(const boost::asio::ip::address& ip) noexcept;
                 bool                                                    SendIPv6TransitPacket(Byte* packet, int packet_length) noexcept;
@@ -228,6 +227,7 @@ namespace ppp {
                 ContextPtr                                              context_;
                 boost::asio::ip::udp::endpoint                          dnsserverEP_;
                 boost::asio::ip::address                                interfaceIP_;
+                ppp::string                                             tun_name_;
                 ppp::string                                             ipv6_neighbor_proxy_ifname_;
                 ITapPtr                                                 ipv6_transit_tap_;
                 VirtualEthernetNetworkTcpipConnectionTable              connections_;

--- a/ppp/configurations/AppConfiguration.cpp
+++ b/ppp/configurations/AppConfiguration.cpp
@@ -115,7 +115,6 @@ namespace ppp {
             config.server.ipv6.prefix_length = 64;
             config.server.ipv6.routed_prefix = true;
             config.server.ipv6.neighbor_proxy = false;
-            config.server.ipv6.neighbor_proxy_provider = "kernel";
             config.server.ipv6.gateway = "";
             config.server.ipv6.dns1 = "";
             config.server.ipv6.dns2 = "";
@@ -164,7 +163,6 @@ namespace ppp {
                     &config.server.ipv6.dns1,
                     &config.server.ipv6.dns2,
                     &config.server.ipv6.stable_secret,
-                    &config.server.ipv6.neighbor_proxy_provider,
                     &config.server.ipv6.allocation,
                     &config.client.guid,
                     &config.client.server,
@@ -853,7 +851,6 @@ namespace ppp {
             AssignIfPresent(config.server.ipv6.prefix_length, json["server"]["ipv6"]["prefix-length"]);
             AssignBoolIfPresent(config.server.ipv6.routed_prefix, json["server"]["ipv6"]["routed-prefix"]);
             AssignBoolIfPresent(config.server.ipv6.neighbor_proxy, json["server"]["ipv6"]["neighbor-proxy"]);
-            AssignIfPresent(config.server.ipv6.neighbor_proxy_provider, json["server"]["ipv6"]["neighbor-proxy-provider"]);
             AssignIfPresent(config.server.ipv6.gateway, json["server"]["ipv6"]["gateway"]);
             AssignIfPresent(config.server.ipv6.dns1, json["server"]["ipv6"]["dns1"]);
             AssignIfPresent(config.server.ipv6.dns2, json["server"]["ipv6"]["dns2"]);
@@ -1035,7 +1032,6 @@ namespace ppp {
             server["ipv6"]["prefix-length"] = config.server.ipv6.prefix_length;
             server["ipv6"]["routed-prefix"] = config.server.ipv6.routed_prefix;
             server["ipv6"]["neighbor-proxy"] = config.server.ipv6.neighbor_proxy;
-            server["ipv6"]["neighbor-proxy-provider"] = config.server.ipv6.neighbor_proxy_provider;
             server["ipv6"]["gateway"] = config.server.ipv6.gateway;
             server["ipv6"]["dns1"] = config.server.ipv6.dns1;
             server["ipv6"]["dns2"] = config.server.ipv6.dns2;

--- a/ppp/configurations/AppConfiguration.h
+++ b/ppp/configurations/AppConfiguration.h
@@ -139,7 +139,6 @@ namespace ppp {
                     int                                                     prefix_length;
                     bool                                                    routed_prefix;
                     bool                                                    neighbor_proxy;
-                    ppp::string                                             neighbor_proxy_provider;
                     ppp::string                                             gateway;
                     ppp::string                                             dns1;
                     ppp::string                                             dns2;

--- a/windows/ppp/win32/network/NetworkInterface.cpp
+++ b/windows/ppp/win32/network/NetworkInterface.cpp
@@ -1302,6 +1302,17 @@ namespace ppp
                 return ExecuteNetshCommand(command);
             }
 
+            bool SetIPv6DefaultRoute(int interface_index, int metric) noexcept {
+                ppp::string interface_name = GetInterfaceName(interface_index);
+                if (interface_name.empty()) {
+                    return false;
+                }
+
+                char command[1200];
+                snprintf(command, sizeof(command), "netsh interface ipv6 add route ::/0 interface=\"%s\" metric=%d store=active", interface_name.data(), std::max<int>(1, metric));
+                return ExecuteNetshCommand(command);
+            }
+
             bool SetIPv6DefaultGateway(int interface_index, const ppp::string& gateway, int metric) noexcept {
                 ppp::string interface_name = GetInterfaceName(interface_index);
                 if (interface_name.empty() || gateway.empty()) {

--- a/windows/ppp/win32/network/NetworkInterface.h
+++ b/windows/ppp/win32/network/NetworkInterface.h
@@ -73,6 +73,7 @@ namespace ppp
             bool                                                SetIPAddresses(const ppp::string& interface_name, const ppp::string& ip, const ppp::string& mask) noexcept;
             bool                                                SetIPv6Address(int interface_index, const ppp::string& ip, int prefix_length) noexcept;
             bool                                                DeleteIPv6Address(int interface_index, const ppp::string& ip) noexcept;
+            bool                                                SetIPv6DefaultRoute(int interface_index, int metric) noexcept;
             bool                                                SetIPv6DefaultGateway(int interface_index, const ppp::string& gateway, int metric) noexcept;
             bool                                                DeleteIPv6DefaultGateway(int interface_index) noexcept;
             bool                                                SetIPAddresses(int interface_index, const ppp::vector<ppp::string>& ips, const ppp::vector<ppp::string>& masks) noexcept;


### PR DESCRIPTION
## 变更概述
这次补充了两部分 IPv6 相关改动：
1. 补齐 IPv6 NAT 模式下的客户端默认路由、Linux 侧 NAT66 环境准备以及内核 IPv6 转发开启逻辑
2. 调整服务端 IPv6 service TUN 的命名行为，并移除 ndppd 配置同步/provider 相关逻辑，收敛外部环境管理边界
## 具体变更
### 1. 完善 IPv6 NAT 模式能力
补齐了 NAT 模式下缺失的运行链路：
- Linux 服务端启动时，在 IPv6 NAT 模式下自动开启 `net.ipv6.conf.all.forwarding=1`
- 自动尝试通过 `nft` 配置 IPv6 NAT66 / FORWARD / POSTROUTING 规则
- 如果 `nft` 不可用，则回退到 `ip6tables` 进行同等规则设置
- 客户端在 NAT 模式下，如果没有显式 IPv6 gateway，也会按平台补齐默认 IPv6 路由处理
- Windows 侧新增无显式 gateway 时的 IPv6 默认路由设置能力
这部分改动让 `nat` 模式不再只停留在控制面定义，而是具备了实际对外访问所需的最小运行能力。
### 2. 服务端 TUN 默认名与 ndppd 收敛
对服务端 IPv6 service TUN 和邻居代理逻辑做了收敛：
- 服务端 IPv6 service TUN 不再硬编码为 `openppp2v6`
- 如果传入 `--tun=<name>`，则沿用该名称
- 如果未传入 `--tun`，则默认使用 `ppp`
- 删除了 `ndppd` 配置同步逻辑
- 删除了 `neighbor_proxy_provider` 配置项及其相关分支处理
- 保留内核侧必要的 neighbor proxy / host route 能力，但不再生成或同步 `ndppd` 配置文件
这样可以避免把 PPP 本身扩展成外部组件配置/生命周期管理器，同时保留 IPv6 会话分配和最小必要路由能力。
## 设计取向
这次调整继续保持以下方向：
- PPP 负责 IPv6 会话参数下发与客户端应用
- PPP 负责隧道侧最小必要路由与 NAT 运行准备
- 不再把 `ndppd` 配置生成作为核心能力的一部分
- 不引入 VMUX / AGG / 端口映射相关范围外改动
## 验证情况
已在 PR 分支重新编译验证通过：
- IPv6 NAT 路由与 Linux forwarding 相关修改已通过构建
- 服务端 TUN 默认名与 ndppd sync/provider 清理后已通过构建
## 相关影响
这两次补充之后，PR 分支在以下方面更完整：
- IPv6 NAT 模式具备实际外网访问链路
- 服务端 IPv6 TUN 命名行为更一致
- 外部 `ndppd` 配置同步逻辑已被移除
- IPv6 运行语义更接近“会话内自洽 + 最小必要宿主机准备”的边界