### PR TITLE
Improve Linux multiqueue handling for server IPv6 transit tun

### DIFF
--- a/linux/ppp/tap/TapLinux.cpp
+++ b/linux/ppp/tap/TapLinux.cpp
@@ -967,6 +967,8 @@ namespace ppp {
                 return true;
             }
 
+            tun_ssmt_fds_size_--;
+            tun_ssmt_sds_.pop_back();
             ppp::net::Socket::Closestream(sd);
             return false;
         }

--- a/main.cpp
+++ b/main.cpp
@@ -1331,7 +1331,7 @@ bool PppApplication::PreparedLoopbackEnvironment(const std::shared_ptr<NetworkIn
 #endif
 
             // Create server switcher
-            ethernet = ppp::make_shared_object<VirtualEthernetSwitcher>(configuration, network_interface->ComponentId);
+            ethernet = ppp::make_shared_object<VirtualEthernetSwitcher>(configuration, network_interface->ComponentId, network_interface->Ssmt, network_interface->SsmtMQ);
             if (NULLPTR == ethernet)
             {
                 break;

--- a/main.cpp
+++ b/main.cpp
@@ -1654,9 +1654,9 @@ void PppApplication::PrintHelpInformation() noexcept
         col_description_width, "SSMT thread optimization", 
         col_default_width, "0");
 #elif defined(_LINUX)
-    printf("│ %-*s │ %-*s │ %-*s │\n", 
-        col_option_width, "--tun-ssmt=<N>[/<mode>]", 
-        col_description_width, "SSMT threads (N), mode: st or mq (optional)", 
+    printf("│ %-*s │ %-*s │ %-*s │\n",
+        col_option_width, "--tun-ssmt=<N>[/<mode>]",
+        col_description_width, "SSMT threads (N), mode: st or mq; mq opens one Linux tun queue per worker",
         col_default_width, "0/st");
 #endif
     

--- a/ppp/app/server/VirtualEthernetExchanger.cpp
+++ b/ppp/app/server/VirtualEthernetExchanger.cpp
@@ -119,6 +119,17 @@ namespace ppp {
                 Finalize();
             }
 
+            int VirtualEthernetExchanger::GetPreferredTunFd() noexcept {
+                SynchronizedObjectScope scope(syncobj_);
+                return preferred_tun_fd_;
+            }
+
+            void VirtualEthernetExchanger::SetPreferredTunFd(int fd) noexcept {
+                SynchronizedObjectScope scope(syncobj_);
+                preferred_tun_fd_ = fd;
+                DebugLog("server ipv6 transit preferred-fd update session=%s fd=%d", auxiliary::StringAuxiliary::Int128ToGuidString(GetId()).data(), fd);
+            }
+
             void VirtualEthernetExchanger::Dispose() noexcept {
                 auto self = shared_from_this();
                 std::shared_ptr<boost::asio::io_context> context = GetContext();
@@ -180,7 +191,6 @@ namespace ppp {
                 if (switcher_) {
                     VirtualEthernetInformationExtensions extensions;
                     if (switcher_->BuildInformationIPv6Extensions(GetId(), extensions)) {
-                        switcher_->UpdateIPv6TransitAffinityFd(extensions.AssignedIPv6Address, -1);
                         switcher_->DeleteIPv6Exchanger(GetId(), extensions.AssignedIPv6Address);
                     }
                 }

--- a/ppp/app/server/VirtualEthernetExchanger.cpp
+++ b/ppp/app/server/VirtualEthernetExchanger.cpp
@@ -180,6 +180,7 @@ namespace ppp {
                 if (switcher_) {
                     VirtualEthernetInformationExtensions extensions;
                     if (switcher_->BuildInformationIPv6Extensions(GetId(), extensions)) {
+                        switcher_->UpdateIPv6TransitAffinityFd(extensions.AssignedIPv6Address, -1);
                         switcher_->DeleteIPv6Exchanger(GetId(), extensions.AssignedIPv6Address);
                     }
                 }

--- a/ppp/app/server/VirtualEthernetExchanger.h
+++ b/ppp/app/server/VirtualEthernetExchanger.h
@@ -68,7 +68,7 @@ namespace ppp {
                     const Int128&                                                           id) noexcept;
                 virtual ~VirtualEthernetExchanger() noexcept;   
     
-            public: 
+            public:
                 virtual bool                                                                Update(UInt64 now) noexcept;
                 virtual bool                                                                Open() noexcept;
                 virtual void                                                                Dispose() noexcept;
@@ -78,6 +78,8 @@ namespace ppp {
                 VirtualEthernetManagedServerPtr                                             GetManagedServer() noexcept { return managed_server_; }
                 ITransmissionStatisticsPtr                                                  GetStatistics() noexcept    { return statistics_; }
                 std::shared_ptr<vmux::vmux_net>                                             GetMux() noexcept           { return mux_; }
+                int                                                                         GetPreferredTunFd() noexcept;
+                void                                                                        SetPreferredTunFd(int fd) noexcept;
 
             protected:  
                 virtual bool                                                                OnLan(const ITransmissionPtr& transmission, uint32_t ip, uint32_t mask, YieldContext& y) noexcept override;
@@ -159,6 +161,7 @@ namespace ppp {
             private:    
                 bool                                                                        disposed_ = false;
                 uint32_t                                                                    address_  = 0;
+                int                                                                         preferred_tun_fd_ = -1;
                 VirtualEthernetSwitcherPtr                                                  switcher_;
                 std::shared_ptr<Byte>                                                       buffer_;
                 FirewallPtr                                                                 firewall_;

--- a/ppp/app/server/VirtualEthernetSwitcher.cpp
+++ b/ppp/app/server/VirtualEthernetSwitcher.cpp
@@ -342,36 +342,6 @@ namespace ppp {
                 return tail == ipv6s_.end() ? NULLPTR : tail->second;
             }
 
-            int VirtualEthernetSwitcher::FindIPv6TransitAffinityFd(const boost::asio::ip::address& ip) noexcept {
-                if (!ip.is_v6()) {
-                    return -1;
-                }
-
-                std::string ip_std = ip.to_string();
-                ppp::string ip_key(ip_std.data(), ip_std.size());
-
-                SynchronizedObjectScope scope(syncobj_);
-                auto tail = ipv6_transit_affinity_.find(ip_key);
-                return tail == ipv6_transit_affinity_.end() ? -1 : tail->second;
-            }
-
-            void VirtualEthernetSwitcher::UpdateIPv6TransitAffinityFd(const boost::asio::ip::address& ip, int fd) noexcept {
-                if (!ip.is_v6()) {
-                    return;
-                }
-
-                std::string ip_std = ip.to_string();
-                ppp::string ip_key(ip_std.data(), ip_std.size());
-
-                SynchronizedObjectScope scope(syncobj_);
-                if (fd < 0) {
-                    ipv6_transit_affinity_.erase(ip_key);
-                }
-                else {
-                    ipv6_transit_affinity_[ip_key] = fd;
-                }
-            }
-
             bool VirtualEthernetSwitcher::OpenIPv6NeighborProxyIfNeed() noexcept {
 #if defined(_LINUX)
                 const auto& ipv6 = configuration_->server.ipv6;
@@ -1072,12 +1042,16 @@ namespace ppp {
                 boost::asio::ip::address_v6 source;
                 boost::asio::ip::address_v6 destination;
                 if (ParseVirtualEthernetIPv6Header(packet, packet_length, source, destination)) {
-                    int affinity_fd = FindIPv6TransitAffinityFd(destination);
-                    if (affinity_fd >= 0) {
-                        int last_fd = ppp::tap::TapLinux::SetLastHandle(affinity_fd);
-                        bool ok = tap->Output(packet, packet_length);
-                        ppp::tap::TapLinux::SetLastHandle(last_fd);
-                        return ok;
+                    VirtualEthernetExchangerPtr exchanger = FindIPv6Exchanger(destination);
+                    if (NULLPTR != exchanger) {
+                        int affinity_fd = exchanger->GetPreferredTunFd();
+                        if (affinity_fd >= 0) {
+                            DebugLog("server ipv6 transit preferred-fd hit session=%s fd=%d", auxiliary::StringAuxiliary::Int128ToGuidString(exchanger->GetId()).data(), affinity_fd);
+                            int last_fd = ppp::tap::TapLinux::SetLastHandle(affinity_fd);
+                            bool ok = tap->Output(packet, packet_length);
+                            ppp::tap::TapLinux::SetLastHandle(last_fd);
+                            return ok;
+                        }
                     }
                 }
 #endif
@@ -1130,7 +1104,7 @@ namespace ppp {
                 }
 
 #if defined(_LINUX)
-                UpdateIPv6TransitAffinityFd(destination, ppp::tap::TapLinux::GetLastHandle());
+                exchanger->SetPreferredTunFd(ppp::tap::TapLinux::GetLastHandle());
 #endif
 
                 app::protocol::ClampTcpMssIPv6(packet, packet_length, app::protocol::ComputeDynamicTcpMss(false, 80));
@@ -1676,8 +1650,6 @@ namespace ppp {
 
                     exchangers = std::move(exchangers_);
                     exchangers_.clear();
-
-                    ipv6_transit_affinity_.clear();
 
                     connections = std::move(connections_);
                     connections_.clear();

--- a/ppp/app/server/VirtualEthernetSwitcher.cpp
+++ b/ppp/app/server/VirtualEthernetSwitcher.cpp
@@ -34,7 +34,7 @@ using ppp::threading::Executors;
 using ppp::coroutines::YieldContext;
 using ppp::collections::Dictionary;
 
-static void DebugLog(const char* format, ...) noexcept {}
+extern void DebugLog(const char* format, ...) noexcept;
 
 namespace ppp {
     namespace transmissions {
@@ -48,11 +48,13 @@ namespace ppp {
 
     namespace app {
         namespace server {
-            VirtualEthernetSwitcher::VirtualEthernetSwitcher(const AppConfigurationPtr& configuration, const ppp::string& tun_name) noexcept
+            VirtualEthernetSwitcher::VirtualEthernetSwitcher(const AppConfigurationPtr& configuration, const ppp::string& tun_name, int tun_ssmt, bool tun_ssmt_mq) noexcept
                 : disposed_(false)
                 , configuration_(configuration)
                 , context_(Executors::GetDefault())
                 , tun_name_(tun_name)
+                , tun_ssmt_(std::max<int>(0, tun_ssmt))
+                , tun_ssmt_mq_(tun_ssmt_mq)
                 , static_echo_socket_(*context_)
                 , static_echo_bind_port_(IPEndPoint::MinPort) {
                 
@@ -253,7 +255,7 @@ namespace ppp {
                         auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data(),
                         ipv6.routed_prefix ? "yes" : "no",
                         ipv6.neighbor_proxy ? "yes" : "no",
-                        "kernel",
+                        ipv6.neighbor_proxy_provider.empty() ? "kernel" : ipv6.neighbor_proxy_provider.data(),
                         (unsigned)extensions.AssignedIPv6PrefixLength);
                 }
 
@@ -273,6 +275,7 @@ namespace ppp {
                     return false;
                 }
 
+                bool need_ndppd_sync = false;
                 {
                     SynchronizedObjectScope scope(syncobj_);
                     for (auto tail = ipv6s_.begin(); tail != ipv6s_.end();) {
@@ -287,6 +290,10 @@ namespace ppp {
                     ipv6s_[ip_key] = exchanger;
                     AddIPv6TransitRoute(ip);
                     AddIPv6NeighborProxy(ip);
+                    need_ndppd_sync = false;
+                }
+                if (need_ndppd_sync) {
+                    SyncNdppdNeighborProxy();
                 }
                 return true;
             }
@@ -299,6 +306,7 @@ namespace ppp {
                 std::string ip_std = ip.to_string();
                 ppp::string ip_key(ip_std.data(), ip_std.size());
 
+                bool need_ndppd_sync = false;
                 {
                     SynchronizedObjectScope scope(syncobj_);
                     auto tail = ipv6s_.find(ip_key);
@@ -313,6 +321,10 @@ namespace ppp {
                     DeleteIPv6TransitRoute(ip);
                     DeleteIPv6NeighborProxy(ip);
                     ipv6s_.erase(tail);
+                    need_ndppd_sync = false;
+                }
+                if (need_ndppd_sync) {
+                    SyncNdppdNeighborProxy();
                 }
                 return true;
             }
@@ -337,6 +349,27 @@ namespace ppp {
                     return true;
                 }
 
+                ppp::string provider = ToLower(ipv6.neighbor_proxy_provider);
+                if (provider.empty()) {
+                    provider = "kernel";
+                }
+
+                DebugLog("server ipv6 neighbor proxy provider=%s", provider.data());
+                if (provider == "ndppd") {
+                    DebugLog("server ipv6 ndppd provider is externally managed; skip in-process config generation");
+                    return true;
+                }
+
+                if (provider == "manual" || provider == "external") {
+                    DebugLog("server ipv6 neighbor proxy provider=%s externally managed; skip in-process setup", provider.data());
+                    return true;
+                }
+
+                if (provider != "kernel") {
+                    DebugLog("server ipv6 neighbor proxy provider=%s not yet implemented in-process", provider.data());
+                    return true;
+                }
+
                 ppp::string uplink_name;
                 UInt32 address = 0;
                 UInt32 mask = 0;
@@ -351,6 +384,78 @@ namespace ppp {
 
                 ipv6_neighbor_proxy_ifname_ = uplink_name;
                 DebugLog("server ipv6 neighbor proxy enabled if=%s", uplink_name.data());
+#endif
+                return true;
+            }
+
+            bool VirtualEthernetSwitcher::CloseIPv6NeighborProxyIfNeed() noexcept {
+#if defined(_LINUX)
+                if (ipv6_neighbor_proxy_ifname_.empty()) {
+                    return true;
+                }
+
+                bool ok = ppp::tap::TapLinux::DisableIPv6NeighborProxy(ipv6_neighbor_proxy_ifname_);
+                DebugLog("server ipv6 neighbor proxy disabled if=%s status=%s", ipv6_neighbor_proxy_ifname_.data(), ok ? "ok" : "fail");
+                ipv6_neighbor_proxy_ifname_.clear();
+#endif
+                return true;
+            }
+
+            bool VirtualEthernetSwitcher::SyncNdppdNeighborProxy() noexcept {
+#if defined(_LINUX)
+                const auto& ipv6 = configuration_->server.ipv6;
+                if (!ipv6.enabled || ToLower(ipv6.mode) != "prefix" || !ipv6.neighbor_proxy) {
+                    return true;
+                }
+
+                ppp::string uplink_name;
+                UInt32 address = 0;
+                UInt32 mask = 0;
+                UInt32 gw = 0;
+                if (!ppp::tap::TapLinux::GetPreferredNetworkInterface(uplink_name, address, mask, gw, ppp::string())) {
+                    return false;
+                }
+
+                ppp::string config_path = "/tmp/openppp2-ndppd.conf";
+                ppp::string config_text = "proxy ";
+                config_text += uplink_name;
+                config_text += " {\n";
+
+                int rules = 0;
+                {
+                    SynchronizedObjectScope scope(syncobj_);
+                    for (const auto& [ip_key, exchanger] : ipv6s_) {
+                        if (NULLPTR == exchanger) {
+                            continue;
+                        }
+
+                        config_text += "  rule ";
+                        config_text += ip_key;
+                        config_text += "/128 {\n";
+                        config_text += "    static\n";
+                        config_text += "  }\n";
+                        rules++;
+                    }
+                }
+
+                if (rules < 1) {
+                    config_text += "  rule ";
+                    config_text += ipv6.prefix;
+                    config_text += "/";
+                    config_text += stl::to_string<ppp::string>(ipv6.prefix_length);
+                    config_text += " {\n";
+                    config_text += "    static\n";
+                    config_text += "  }\n";
+                }
+
+                config_text += "}\n";
+
+                if (!ppp::io::File::WriteAllBytes(config_path.data(), config_text.data(), static_cast<int>(config_text.size()))) {
+                    return false;
+                }
+
+                DebugLog("server ipv6 ndppd config synced path=%s uplink=%s rules=%d", config_path.data(), uplink_name.data(), rules);
+                DebugLog("server ipv6 ndppd reload required path=%s", config_path.data());
 #endif
                 return true;
             }
@@ -646,16 +751,22 @@ namespace ppp {
 
                 VirtualEthernetInformation fallback_information;
                 const VirtualEthernetInformation* established_information = i.get();
-                if (NULLPTR == established_information && configuration_->server.ipv6.enabled) {
+                if (NULLPTR == established_information && configuration_->server.ipv6.enabled && configuration_->server.backend.empty()) {
                     fallback_information.Clear();
                     fallback_information.BandwidthQoS = 0;
                     fallback_information.IncomingTraffic = std::numeric_limits<UInt64>::max();
                     fallback_information.OutgoingTraffic = std::numeric_limits<UInt64>::max();
                     fallback_information.ExpiredTime = std::numeric_limits<UInt32>::max();
                     established_information = &fallback_information;
-                    const char* reason = configuration_->server.backend.empty() ? "no-managed-backend" : "managed-info-empty";
+                    const char* reason = "no-managed-backend";
                     DebugLog("server establish using local bootstrap info session=%s", auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data());
                     DebugLog("server establish info source=local-bootstrap reason=%s session=%s", reason, auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data());
+                }
+
+                if (NULLPTR == established_information && !configuration_->server.backend.empty()) {
+                    DebugLog("server establish aborted reason=managed-info-empty session=%s", auxiliary::StringAuxiliary::Int128ToGuidString(session_id).data());
+                    DeleteExchanger(channel.get());
+                    return false;
                 }
 
                 bool run = true;
@@ -1057,10 +1168,86 @@ namespace ppp {
                         return switcher->ReceiveIPv6TransitPacket(reinterpret_cast<Byte*>(e.Packet), e.PacketLength);
                     };
 
+                if (!OpenIPv6TransitSsmtIfNeed(tap)) {
+                    tap->Dispose();
+                    return false;
+                }
+
                 ipv6_transit_tap_ = tap;
                 DebugLog("server ipv6 transit tap opened name=%s address=%s/%d", tap->GetId().data(), transit_ip.data(), prefix_length);
 #endif
                 return true;
+            }
+
+            bool VirtualEthernetSwitcher::OpenIPv6TransitSsmtIfNeed(const ITapPtr& tap) noexcept {
+#if defined(_LINUX)
+                if (tun_ssmt_ <= 0 || !tun_ssmt_mq_) {
+                    return true;
+                }
+
+                auto linux_tap = std::dynamic_pointer_cast<ppp::tap::TapLinux>(tap);
+                if (NULLPTR == linux_tap) {
+                    return false;
+                }
+
+                ppp::vector<std::shared_ptr<boost::asio::io_context>> contexts;
+                contexts.reserve(tun_ssmt_);
+                for (int i = 0; i < tun_ssmt_; ++i) {
+                    std::shared_ptr<boost::asio::io_context> worker = make_shared_object<boost::asio::io_context>();
+                    if (NULLPTR == worker) {
+                        for (auto& context : contexts) {
+                            context->stop();
+                        }
+                        return false;
+                    }
+
+                    std::thread ssmt_thread(
+                        [worker]() noexcept {
+                            if (ppp::RT) {
+                                SetThreadPriorityToMaxLevel();
+                            }
+
+                            SetThreadName("srv-ssmt");
+                            boost::system::error_code ec;
+                            boost::asio::io_context::work work(*worker);
+                            worker->restart();
+                            worker->run(ec);
+                        });
+                    ssmt_thread.detach();
+
+                    if (!linux_tap->Ssmt(worker)) {
+                        worker->stop();
+                        for (auto& context : contexts) {
+                            context->stop();
+                        }
+                        return false;
+                    }
+
+                    contexts.emplace_back(worker);
+                }
+                DebugLog("server ipv6 transit multiqueue enabled name=%s workers=%d", tap->GetId().data(), tun_ssmt_);
+
+                SynchronizedObjectScope scope(syncobj_);
+                ipv6_transit_ssmt_contexts_ = std::move(contexts);
+#else
+                (void)tap;
+#endif
+                return true;
+            }
+
+            void VirtualEthernetSwitcher::CloseIPv6TransitSsmtContexts() noexcept {
+#if defined(_LINUX)
+                ppp::vector<std::shared_ptr<boost::asio::io_context>> contexts;
+                {
+                    SynchronizedObjectScope scope(syncobj_);
+                    contexts = std::move(ipv6_transit_ssmt_contexts_);
+                    ipv6_transit_ssmt_contexts_.clear();
+                }
+
+                for (auto& context : contexts) {
+                    context->stop();
+                }
+#endif
             }
 
             bool VirtualEthernetSwitcher::OpenLogger() noexcept {
@@ -1449,7 +1636,9 @@ namespace ppp {
                     break;
                 }
 
+                CloseIPv6TransitSsmtContexts();
                 CloseAlwaysTimeout();
+                CloseIPv6NeighborProxyIfNeed();
 
                 CancelAllResolver(tresolver);
                 CancelAllResolver(uresolver);

--- a/ppp/app/server/VirtualEthernetSwitcher.cpp
+++ b/ppp/app/server/VirtualEthernetSwitcher.cpp
@@ -342,6 +342,36 @@ namespace ppp {
                 return tail == ipv6s_.end() ? NULLPTR : tail->second;
             }
 
+            int VirtualEthernetSwitcher::FindIPv6TransitAffinityFd(const boost::asio::ip::address& ip) noexcept {
+                if (!ip.is_v6()) {
+                    return -1;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_key(ip_std.data(), ip_std.size());
+
+                SynchronizedObjectScope scope(syncobj_);
+                auto tail = ipv6_transit_affinity_.find(ip_key);
+                return tail == ipv6_transit_affinity_.end() ? -1 : tail->second;
+            }
+
+            void VirtualEthernetSwitcher::UpdateIPv6TransitAffinityFd(const boost::asio::ip::address& ip, int fd) noexcept {
+                if (!ip.is_v6()) {
+                    return;
+                }
+
+                std::string ip_std = ip.to_string();
+                ppp::string ip_key(ip_std.data(), ip_std.size());
+
+                SynchronizedObjectScope scope(syncobj_);
+                if (fd < 0) {
+                    ipv6_transit_affinity_.erase(ip_key);
+                }
+                else {
+                    ipv6_transit_affinity_[ip_key] = fd;
+                }
+            }
+
             bool VirtualEthernetSwitcher::OpenIPv6NeighborProxyIfNeed() noexcept {
 #if defined(_LINUX)
                 const auto& ipv6 = configuration_->server.ipv6;
@@ -1038,6 +1068,20 @@ namespace ppp {
                     return false;
                 }
 
+#if defined(_LINUX)
+                boost::asio::ip::address_v6 source;
+                boost::asio::ip::address_v6 destination;
+                if (ParseVirtualEthernetIPv6Header(packet, packet_length, source, destination)) {
+                    int affinity_fd = FindIPv6TransitAffinityFd(destination);
+                    if (affinity_fd >= 0) {
+                        int last_fd = ppp::tap::TapLinux::SetLastHandle(affinity_fd);
+                        bool ok = tap->Output(packet, packet_length);
+                        ppp::tap::TapLinux::SetLastHandle(last_fd);
+                        return ok;
+                    }
+                }
+#endif
+
                 return tap->Output(packet, packet_length);
             }
 
@@ -1084,6 +1128,10 @@ namespace ppp {
                 if (NULLPTR == transmission) {
                     return false;
                 }
+
+#if defined(_LINUX)
+                UpdateIPv6TransitAffinityFd(destination, ppp::tap::TapLinux::GetLastHandle());
+#endif
 
                 app::protocol::ClampTcpMssIPv6(packet, packet_length, app::protocol::ComputeDynamicTcpMss(false, 80));
 
@@ -1628,6 +1676,8 @@ namespace ppp {
 
                     exchangers = std::move(exchangers_);
                     exchangers_.clear();
+
+                    ipv6_transit_affinity_.clear();
 
                     connections = std::move(connections_);
                     connections_.clear();

--- a/ppp/app/server/VirtualEthernetSwitcher.h
+++ b/ppp/app/server/VirtualEthernetSwitcher.h
@@ -41,7 +41,6 @@ namespace ppp {
                 typedef std::unordered_map<ppp::string, std::shared_ptr<class VirtualEthernetExchanger>> IPv6ExchangerTable;
                 typedef ppp::cryptography::Ciphertext                   Ciphertext;
                 typedef std::shared_ptr<Ciphertext>                     CiphertextPtr;
-                typedef std::unordered_map<ppp::string, int>            IPv6TransitTunAffinityTable;
 
             public:
                 typedef ppp::app::protocol::VirtualEthernetInformation  VirtualEthernetInformation;
@@ -185,8 +184,6 @@ namespace ppp {
                 bool                                                    AddIPv6Exchanger(const Int128& session_id, const boost::asio::ip::address& ip) noexcept;
                 bool                                                    DeleteIPv6Exchanger(const Int128& session_id, const boost::asio::ip::address& ip) noexcept;
                 VirtualEthernetExchangerPtr                             FindIPv6Exchanger(const boost::asio::ip::address& ip) noexcept;
-                int                                                     FindIPv6TransitAffinityFd(const boost::asio::ip::address& ip) noexcept;
-                void                                                    UpdateIPv6TransitAffinityFd(const boost::asio::ip::address& ip, int fd) noexcept;
                 bool                                                    OpenIPv6NeighborProxyIfNeed() noexcept;
                 bool                                                    AddIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept;
                 bool                                                    DeleteIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept;
@@ -236,7 +233,6 @@ namespace ppp {
                 int                                                     tun_ssmt_ = 0;
                 bool                                                    tun_ssmt_mq_ = false;
                 ppp::string                                             ipv6_neighbor_proxy_ifname_;
-                IPv6TransitTunAffinityTable                             ipv6_transit_affinity_;
                 ITapPtr                                                 ipv6_transit_tap_;
                 ppp::vector<std::shared_ptr<boost::asio::io_context>>   ipv6_transit_ssmt_contexts_;
                 VirtualEthernetNetworkTcpipConnectionTable              connections_;

--- a/ppp/app/server/VirtualEthernetSwitcher.h
+++ b/ppp/app/server/VirtualEthernetSwitcher.h
@@ -41,6 +41,7 @@ namespace ppp {
                 typedef std::unordered_map<ppp::string, std::shared_ptr<class VirtualEthernetExchanger>> IPv6ExchangerTable;
                 typedef ppp::cryptography::Ciphertext                   Ciphertext;
                 typedef std::shared_ptr<Ciphertext>                     CiphertextPtr;
+                typedef std::unordered_map<ppp::string, int>            IPv6TransitTunAffinityTable;
 
             public:
                 typedef ppp::app::protocol::VirtualEthernetInformation  VirtualEthernetInformation;
@@ -184,6 +185,8 @@ namespace ppp {
                 bool                                                    AddIPv6Exchanger(const Int128& session_id, const boost::asio::ip::address& ip) noexcept;
                 bool                                                    DeleteIPv6Exchanger(const Int128& session_id, const boost::asio::ip::address& ip) noexcept;
                 VirtualEthernetExchangerPtr                             FindIPv6Exchanger(const boost::asio::ip::address& ip) noexcept;
+                int                                                     FindIPv6TransitAffinityFd(const boost::asio::ip::address& ip) noexcept;
+                void                                                    UpdateIPv6TransitAffinityFd(const boost::asio::ip::address& ip, int fd) noexcept;
                 bool                                                    OpenIPv6NeighborProxyIfNeed() noexcept;
                 bool                                                    AddIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept;
                 bool                                                    DeleteIPv6NeighborProxy(const boost::asio::ip::address& ip) noexcept;
@@ -233,6 +236,7 @@ namespace ppp {
                 int                                                     tun_ssmt_ = 0;
                 bool                                                    tun_ssmt_mq_ = false;
                 ppp::string                                             ipv6_neighbor_proxy_ifname_;
+                IPv6TransitTunAffinityTable                             ipv6_transit_affinity_;
                 ITapPtr                                                 ipv6_transit_tap_;
                 ppp::vector<std::shared_ptr<boost::asio::io_context>>   ipv6_transit_ssmt_contexts_;
                 VirtualEthernetNetworkTcpipConnectionTable              connections_;

--- a/ppp/app/server/VirtualEthernetSwitcher.h
+++ b/ppp/app/server/VirtualEthernetSwitcher.h
@@ -87,7 +87,7 @@ namespace ppp {
                 typedef std::shared_ptr<VirtualEthernetNamespaceCache>  VirtualEthernetNamespaceCachePtr;
 
             public:
-                VirtualEthernetSwitcher(const AppConfigurationPtr& configuration, const ppp::string& tun_name = ppp::string()) noexcept;
+                VirtualEthernetSwitcher(const AppConfigurationPtr& configuration, const ppp::string& tun_name = ppp::string(), int tun_ssmt = 0, bool tun_ssmt_mq = false) noexcept;
                 virtual ~VirtualEthernetSwitcher() noexcept;
 
             public:
@@ -158,6 +158,8 @@ namespace ppp {
                 void                                                    TickAllConnections(UInt64 now) noexcept;
                 bool                                                    OpenManagedServerIfNeed() noexcept;
                 bool                                                    OpenIPv6TransitIfNeed() noexcept;
+                bool                                                    OpenIPv6TransitSsmtIfNeed(const ITapPtr& tap) noexcept;
+                void                                                    CloseIPv6TransitSsmtContexts() noexcept;
 
             private:
                 VirtualEthernetStaticEchoAllocatedContextPtr            StaticEchoUnallocated(int allocated_id) noexcept;
@@ -228,8 +230,11 @@ namespace ppp {
                 boost::asio::ip::udp::endpoint                          dnsserverEP_;
                 boost::asio::ip::address                                interfaceIP_;
                 ppp::string                                             tun_name_;
+                int                                                     tun_ssmt_ = 0;
+                bool                                                    tun_ssmt_mq_ = false;
                 ppp::string                                             ipv6_neighbor_proxy_ifname_;
                 ITapPtr                                                 ipv6_transit_tap_;
+                ppp::vector<std::shared_ptr<boost::asio::io_context>>   ipv6_transit_ssmt_contexts_;
                 VirtualEthernetNetworkTcpipConnectionTable              connections_;
                 ITransmissionStatisticsPtr                              statistics_;
                 VirtualEthernetManagedServerPtr                         managed_server_;

--- a/ppp/ethernet/VEthernet.cpp
+++ b/ppp/ethernet/VEthernet.cpp
@@ -514,6 +514,7 @@ namespace ppp
             std::vector<std::shared_ptr<boost::asio::io_context>/**/> stop_ssmts;
             for (SynchronizedObjectScope scope(syncobj_);;)
             {
+                ssmt_mq_to_take_effect_ = false;
                 stop_ssmts = std::move(sssmt_);
                 sssmt_.clear();
                 break;
@@ -678,6 +679,8 @@ namespace ppp
                 bool ssmt_ok = linux_tap->Ssmt(context);
                 if (!ssmt_ok)
                 {
+                    context->stop();
+                    sssmt_.pop_back();
                     return false;
                 }
 


### PR DESCRIPTION
## Summary
- stabilize the existing Linux tun multiqueue groundwork and make the queue lifecycle safer
- enable multiqueue workers for the server-side IPv6 transit tun path
- preserve tun fd affinity and formalize it from a temporary destination-based mapping into exchanger-level preferred tun fd tracking
## Background
`upstream/inet6` already contains the IPv6 transit tun path on the server side, and the Linux tun implementation already has partial multiqueue support.
This PR builds on top of that existing foundation rather than introducing multiple virtual interfaces. The goal is to keep a single logical tun device while improving how multiple queue fds are opened, managed, and reused across worker threads.
## What Changed
### 1. Stabilize Linux multiqueue groundwork
- tighten rollback behavior when additional tun queue setup fails
- reset multiqueue activation state more cleanly during shutdown
- clarify the meaning of `--tun-ssmt=<N>/mq` in the CLI help text
### 2. Enable multiqueue on the server IPv6 transit tun
- pass `Ssmt` / `SsmtMQ` configuration into the server switcher
- let the server IPv6 transit tun open extra Linux queue workers when `mq` mode is enabled
- stop and clean up transit tun worker contexts during switcher teardown
### 3. Preserve and formalize tun fd affinity
- first preserve transit tun fd affinity on the server IPv6 transit path
- then refine the model so affinity is tracked per exchanger/session instead of via a temporary global destination-to-fd table
- update affinity only on real transit ingress
- prefer the exchanger's remembered tun fd on transit egress
- add minimal debug logging to help validate preferred-fd updates and hits at runtime
## Why
For Linux multiqueue tun, read-side parallelism alone is not enough. It is also important to preserve queue/fd affinity as much as possible so that traffic read from one tun fd tends to be written back through the same fd when practical.
This PR moves the implementation in that direction while keeping the current architecture intact and avoiding a larger rewrite into multiple virtual interfaces.
## Scope
This PR is intentionally limited to the Linux/server transit tun path and the existing multiqueue infrastructure. It does not introduce multiple virtual tun/tap devices, and it does not attempt a full queue-object refactor yet.
## Files
Main affected areas:
- `linux/ppp/tap/TapLinux.cpp`
- `main.cpp`
- `ppp/ethernet/VEthernet.cpp`
- `ppp/app/server/VirtualEthernetSwitcher.cpp`
- `ppp/app/server/VirtualEthernetSwitcher.h`
- `ppp/app/server/VirtualEthernetExchanger.cpp`
- `ppp/app/server/VirtualEthernetExchanger.h`
## Notes
The implementation keeps the current single logical tun model and improves the multiqueue behavior incrementally. A future follow-up can still introduce a more explicit queue-instance abstraction if that becomes desirable.