### PR TITLE
Fix CLI, Android endpoints, proxy reply, and OpenSSL 4 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ android/android/keystore/*.p12
 android/android/keystore/*.jks
 android/android/keystore/*.keystore
 android/android/keystore/*.properties
+/third-party
+.DS_Store

--- a/android/lib/models/config_profile.dart
+++ b/android/lib/models/config_profile.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import '../utils/server_endpoint.dart';
 
 /// One JSON snapshot kept in profile history (most recent first).
 class ConfigSnapshot {
@@ -91,10 +92,10 @@ class ConfigProfile {
         if (client is Map) {
           final s = client['server']?.toString();
           if (s == null || s.isEmpty) return null;
-          final uri = Uri.tryParse(s);
-          if (uri != null && uri.host.isNotEmpty) {
-            final port = uri.hasPort ? ':${uri.port}' : '';
-            return '${uri.host}$port';
+          final endpoint = ServerEndpoint.parse(s);
+          if (endpoint.host.isNotEmpty) {
+            final port = endpoint.port != null ? ':${endpoint.port}' : '';
+            return '${endpoint.host}$port';
           }
         }
       }

--- a/android/lib/pages/profile_edit_page.dart
+++ b/android/lib/pages/profile_edit_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import '../models/config_profile.dart';
 import '../services/profile_store.dart';
+import '../utils/server_endpoint.dart';
 
 /// Edit (or create) a single ConfigProfile.
 ///
@@ -95,10 +96,9 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
     final key = mapAt('key');
 
     final serverUrl = client['server']?.toString() ?? '';
-    final uri = Uri.tryParse(serverUrl);
-    _serverHostController.text = uri?.host ?? '';
-    _serverPortController.text =
-        (uri != null && uri.hasPort) ? uri.port.toString() : '';
+    final endpoint = ServerEndpoint.parse(serverUrl);
+    _serverHostController.text = endpoint.host;
+    _serverPortController.text = endpoint.port?.toString() ?? '';
     _guidController.text = client['guid']?.toString() ?? '';
     _bandwidthController.text = (client['bandwidth'] ?? 0).toString();
 
@@ -145,7 +145,10 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
     final host = _serverHostController.text.trim();
     final port = int.tryParse(_serverPortController.text.trim()) ?? 0;
     if (host.isNotEmpty) {
-      client['server'] = 'ppp://$host${port > 0 ? ':$port' : ''}/';
+      client['server'] = ServerEndpoint(
+        host: host,
+        port: port > 0 ? port : null,
+      ).toPppUrl();
     }
     if (_guidController.text.trim().isNotEmpty) {
       client['guid'] = _guidController.text.trim();

--- a/android/lib/services/profile_store.dart
+++ b/android/lib/services/profile_store.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/config_profile.dart';
+import '../utils/server_endpoint.dart';
 
 /// Persistent store for the list of config profiles (locations) plus
 /// active selection + raw VPN options. Uses SharedPreferences.
@@ -584,8 +585,8 @@ class ProfileStore {
         if (client is Map) {
           final s = client['server']?.toString();
           if (s != null) {
-            final uri = Uri.tryParse(s);
-            if (uri != null && uri.host.isNotEmpty) return uri.host;
+            final endpoint = ServerEndpoint.parse(s);
+            if (endpoint.host.isNotEmpty) return endpoint.host;
           }
         }
       }

--- a/android/lib/utils/server_endpoint.dart
+++ b/android/lib/utils/server_endpoint.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+class ServerEndpoint {
+  final String host;
+  final int? port;
+
+  const ServerEndpoint({required this.host, this.port});
+
+  static ServerEndpoint parse(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return const ServerEndpoint(host: '');
+
+    const scheme = 'ppp://';
+    if (trimmed.startsWith(scheme)) {
+      final authority = trimmed.substring(scheme.length).split('/').first;
+      if (authority.startsWith('[') || ':'.allMatches(authority).length > 1) {
+        return _parseAuthority(authority);
+      }
+    }
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && uri.host.isNotEmpty) {
+      return ServerEndpoint(host: uri.host, port: uri.hasPort ? uri.port : null);
+    }
+
+    if (trimmed.startsWith(scheme)) {
+      final authority = trimmed.substring(scheme.length).split('/').first;
+      return _parseAuthority(authority);
+    }
+
+    return _parseAuthority(trimmed);
+  }
+
+  static ServerEndpoint _parseAuthority(String authority) {
+    final raw = authority.trim();
+    if (raw.isEmpty) return const ServerEndpoint(host: '');
+
+    if (raw.startsWith('[')) {
+      final end = raw.indexOf(']');
+      if (end > 0) {
+        final host = raw.substring(1, end);
+        final rest = raw.substring(end + 1);
+        final port = rest.startsWith(':') ? int.tryParse(rest.substring(1)) : null;
+        return ServerEndpoint(host: host, port: port);
+      }
+    }
+
+    final colonCount = ':'.allMatches(raw).length;
+    if (colonCount > 1) {
+      final lastColon = raw.lastIndexOf(':');
+      final hostCandidate = raw.substring(0, lastColon);
+      final tail = raw.substring(lastColon + 1);
+      final port = int.tryParse(tail);
+      if (port != null && _isValidIpv6Address(hostCandidate)) {
+        return ServerEndpoint(host: hostCandidate, port: port);
+      }
+      return ServerEndpoint(host: raw);
+    }
+
+    final colon = raw.lastIndexOf(':');
+    if (colon > 0) {
+      final port = int.tryParse(raw.substring(colon + 1));
+      if (port != null) {
+        return ServerEndpoint(host: raw.substring(0, colon), port: port);
+      }
+    }
+    return ServerEndpoint(host: raw);
+  }
+
+  String toPppUrl() {
+    final normalizedHost = host.trim();
+    final urlHost = _needsIpv6Brackets(normalizedHost)
+        ? '[$normalizedHost]'
+        : normalizedHost;
+    return 'ppp://$urlHost${port != null && port! > 0 ? ':$port' : ''}/';
+  }
+
+  static bool _isValidIpv6Address(String value) {
+    return InternetAddress.tryParse(value)?.type == InternetAddressType.IPv6;
+  }
+
+  static bool _needsIpv6Brackets(String host) =>
+      host.contains(':') && !(host.startsWith('[') && host.endsWith(']'));
+}

--- a/android/test/server_endpoint_test.dart
+++ b/android/test/server_endpoint_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openppp2_mobile/utils/server_endpoint.dart';
+
+void main() {
+  group('ServerEndpoint', () {
+    test('parses bracketed IPv6 server URLs', () {
+      final endpoint = ServerEndpoint.parse('ppp://[2001:db8::1]:20000/');
+
+      expect(endpoint.host, '2001:db8::1');
+      expect(endpoint.port, 20000);
+    });
+
+    test('parses legacy unbracketed IPv6 server URLs', () {
+      final endpoint = ServerEndpoint.parse('ppp://2001:db8::1:20000/');
+
+      expect(endpoint.host, '2001:db8::1');
+      expect(endpoint.port, 20000);
+    });
+
+    test('preserves legacy unbracketed IPv6 server URLs without ports', () {
+      final endpoint = ServerEndpoint.parse('ppp://2001:db8::1/');
+
+      expect(endpoint.host, '2001:db8::1');
+      expect(endpoint.port, isNull);
+    });
+
+    test('parses legacy unbracketed IPv4-mapped IPv6 server URLs', () {
+      final endpoint = ServerEndpoint.parse('ppp://::ffff:192.0.2.128:20000/');
+
+      expect(endpoint.host, '::ffff:192.0.2.128');
+      expect(endpoint.port, 20000);
+    });
+
+    test('formats IPv6 host with brackets for URLs', () {
+      final url = ServerEndpoint(host: '2001:db8::1', port: 20000).toPppUrl();
+
+      expect(url, 'ppp://[2001:db8::1]:20000/');
+    });
+
+    test('formats IPv4 and domain hosts without brackets', () {
+      expect(ServerEndpoint(host: '192.0.2.10', port: 20000).toPppUrl(),
+          'ppp://192.0.2.10:20000/');
+      expect(ServerEndpoint(host: 'vpn.example.com', port: 20000).toPppUrl(),
+          'ppp://vpn.example.com:20000/');
+    });
+  });
+}

--- a/ppp/app/ApplicationNetwork.cpp
+++ b/ppp/app/ApplicationNetwork.cpp
@@ -220,7 +220,10 @@ void PppApplication::PullIPList(const ppp::string& command, bool virr) noexcept 
         ppp::set<ppp::string> ips;
         if (chnroutes2_getiplist(ips, nation) > 0) {
             ok = chnroutes2_saveiplist(path, ips);
-            if (!ok && ppp::diagnostics::ErrorCode::Success == ppp::diagnostics::GetLastErrorCode()) {
+            if (ok) {
+                ppp::diagnostics::SetLastErrorCode(ppp::diagnostics::ErrorCode::Success);
+            }
+            else if (ppp::diagnostics::ErrorCode::Success == ppp::diagnostics::GetLastErrorCode()) {
                 ppp::diagnostics::SetLastErrorCode(ppp::diagnostics::ErrorCode::FileWriteFailed);
             }
         }

--- a/ppp/app/PppApplication.cpp
+++ b/ppp/app/PppApplication.cpp
@@ -189,7 +189,9 @@ void PppApplication::ClearTickAlwaysTimeout() noexcept {
 int RunPreparedApplication(const std::shared_ptr<PppApplication>& app, int prepared_status, int argc, const char* argv[]) noexcept {
     if (ppp::HasCommandArgument("--pull-iplist", argc, argv)) {
         app->PullIPList(ppp::GetCommandArgument("--pull-iplist", argc, argv), false);
-        return ppp::diagnostics::GetLastErrorCode() == ppp::diagnostics::ErrorCode::Success ? 0 : -1;
+        int rc = ppp::diagnostics::GetLastErrorCode() == ppp::diagnostics::ErrorCode::Success ? 0 : -1;
+        Executors::Exit();
+        return rc;
     }
 
 #if defined(_WIN32)

--- a/ppp/app/client/proxys/VEthernetSocksProxyConnection.cpp
+++ b/ppp/app/client/proxys/VEthernetSocksProxyConnection.cpp
@@ -325,7 +325,7 @@ namespace ppp {
                         return false;
                     }
 
-                    return true;
+                    return SendSocksRequestReply(GetSocket(), SOCKS_ERR_OK, y);
                 }
 
                 /**

--- a/ppp/stdafx.h
+++ b/ppp/stdafx.h
@@ -296,6 +296,12 @@
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
 
+#include <openssl/opensslv.h>
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 4
+#   ifndef BOOST_ASIO_NO_DEPRECATED
+#       define BOOST_ASIO_NO_DEPRECATED
+#   endif
+#endif
 #include <boost/asio/ssl.hpp>
 #include <boost/beast/ssl.hpp>
 


### PR DESCRIPTION
## Summary
- Exit cleanly after running --pull-iplist and clear successful save errors
- Preserve IPv6 server endpoints in the Android profile editor
- Send SOCKS CONNECT success replies from the proxy path
- Support OpenSSL 4 builds with Boost.Asio and ignore local build artifacts

## Testing
- Not run locally