### PR TITLE
ci(android): rewrite build-android workflow for NDK r26b with source builds and drop _LIBCPP workaround

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,128 +1,351 @@
-# Copyright  : Copyright (C) 2017 ~ 2035 SupersocksR ORG. All rights reserved.
-# Description: PPP PRIVATE NETWORK(TM) 2 – Android NDK builds + Flutter APK.
-# Author     : OpenCode.
-# Date-Time  : 2026/05/03
-
-name: Build · Android
+name: build-openppp2-android-apk
 
 on:
   push:
-    branches: [main]
+    branches: [inet6]
   pull_request:
-    branches: [main]
+    branches: [inet6]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 concurrency:
-  group: build-android-${{ github.ref }}
+  group: build-openppp2-android-apk-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ANDROID_API: "21"
+  BOOST_VERSION: "1.86.0"
+  OPENSSL_VERSION: "3.6.2"
 
 jobs:
-  build:
-    name: Android ${{ matrix.abi }}
+  build-so:
+    name: Android ${{ matrix.ANDROID_ABI }} (ubuntu)
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        include:
-          - abi: arm64-v8a
-            ppp_abi: aarch64
-          - abi: armeabi-v7a
-            ppp_abi: armv7a
-          - abi: x86
-            ppp_abi: x86
-          - abi: x86_64
-            ppp_abi: x64
-
+        ANDROID_ABI: [arm64-v8a, armeabi-v7a, x86, x86_64]
+    env:
+      ANDROID_ABI: ${{ matrix.ANDROID_ABI }}
+      ANDROID_API: "21"
+      BOOST_VERSION: "1.86.0"
+      OPENSSL_VERSION: "3.6.2"
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Cache NDK and dependencies
-        id: cache-ndk
-        uses: actions/cache@v4
+      - name: Checkout openppp2 repository
+        uses: actions/checkout@v6
         with:
-          path: ${{ runner.temp }}/ndk
-          key: android-ndk-r20b-boost174-openssl111i
+          repository: rebecca554owen/openppp2
+          path: openppp2
+          ref: inet6
 
-      - name: Download NDK
-        if: steps.cache-ndk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "${{ runner.temp }}/ndk" && cd "${{ runner.temp }}/ndk"
-          wget -q https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
-          unzip -q android-ndk-r20b-linux-x86_64.zip && rm android-ndk-r20b-linux-x86_64.zip
-          mv android-ndk-r20b abi
+      - name: Cache Android NDK
+        id: cache-android-ndk
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/android-ndk-r26b
+          key: android-ndk-r26b
 
-      - name: Clone Boost for Android
-        if: steps.cache-ndk.outputs.cache-hit != 'true'
+      - name: Download Android NDK r26b
+        if: steps.cache-android-ndk.outputs.cache-hit != 'true'
         run: |
-          mkdir -p "${{ runner.temp }}/ndk"
-          git clone --depth 1 https://github.com/liulilittle/boost-1.74-for-android-r20b-fpic.git "${{ runner.temp }}/ndk/boost"
+          set -euo pipefail
+          cd "${{ runner.temp }}"
+          curl -L --fail -o android-ndk-r26b-linux.zip \
+            https://dl.google.com/android/repository/android-ndk-r26b-linux.zip
+          unzip -q android-ndk-r26b-linux.zip
+          rm android-ndk-r26b-linux.zip
 
-      - name: Clone OpenSSL for Android
-        if: steps.cache-ndk.outputs.cache-hit != 'true'
+      - name: Cache Android third-party dependencies
+        id: cache-android-deps
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/openppp2/third-party
+          key: android-${{ matrix.ANDROID_ABI }}-ndk29-boost-${{ env.BOOST_VERSION }}-fcontext-aapcs-openssl-${{ env.OPENSSL_VERSION }}-ubuntu
+
+      - name: Prepare build variables
         run: |
-          mkdir -p "${{ runner.temp }}/ndk"
-          git clone --depth 1 https://github.com/liulilittle/openssl-1.1.1i-for-android-r20b.git "${{ runner.temp }}/ndk/openssl"
+          set -euo pipefail
+          NDK_ROOT="${{ runner.temp }}/android-ndk-r26b"
+          TOOLCHAIN_DIR="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64"
+          TP="$GITHUB_WORKSPACE/openppp2/third-party"
+
+          test -f "$NDK_ROOT/build/cmake/android.toolchain.cmake"
+
+          # Map ABI to toolchain and OpenSSL suffix
+          case "${{ matrix.ANDROID_ABI }}" in
+            arm64-v8a)
+              CLANG_TRIPLE="aarch64-linux-android"
+              BOOST_TOOLSET_SUFFIX="androidarm64"
+              BOOST_ARCHITECTURE="arm"
+              BOOST_ADDRESS_MODEL="64"
+              BOOST_ABI="aapcs"
+              OPENSSL_SUFFIX="arm64"
+              OPENSSL_TARGET="android-arm64"
+              ;;
+            armeabi-v7a)
+              CLANG_TRIPLE="armv7a-linux-androideabi"
+              BOOST_TOOLSET_SUFFIX="androidarm"
+              BOOST_ARCHITECTURE="arm"
+              BOOST_ADDRESS_MODEL="32"
+              BOOST_ABI="aapcs"
+              OPENSSL_SUFFIX="armeabi-v7a"
+              OPENSSL_TARGET="android-arm"
+              ;;
+            x86)
+              CLANG_TRIPLE="i686-linux-android"
+              BOOST_TOOLSET_SUFFIX="androidx86"
+              BOOST_ARCHITECTURE="x86"
+              BOOST_ADDRESS_MODEL="32"
+              BOOST_ABI="sysv"
+              OPENSSL_SUFFIX="x86"
+              OPENSSL_TARGET="android-x86"
+              ;;
+            x86_64)
+              CLANG_TRIPLE="x86_64-linux-android"
+              BOOST_TOOLSET_SUFFIX="androidx64"
+              BOOST_ARCHITECTURE="x86"
+              BOOST_ADDRESS_MODEL="64"
+              BOOST_ABI="sysv"
+              OPENSSL_SUFFIX="x86-64"
+              OPENSSL_TARGET="android-x86_64"
+              ;;
+          esac
+
+          mkdir -p "$TP"
+
+          {
+            echo "NDK_ROOT=$NDK_ROOT"
+            echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR"
+            echo "THIRD_PARTY_DIR=$TP"
+            echo "BOOST_SRC_DIR=$TP/boost-src"
+            echo "OPENSSL_SRC_DIR=$TP/openssl-src"
+            echo "OPENSSL_OUT_DIR=$TP/openssl-$OPENSSL_SUFFIX"
+            echo "OPENSSL_TARGET=$OPENSSL_TARGET"
+            echo "BOOST_OUT_DIR=$TP/boost/${{ matrix.ANDROID_ABI }}"
+            echo "CLANG_TRIPLE=$CLANG_TRIPLE"
+            echo "BOOST_TOOLSET_SUFFIX=$BOOST_TOOLSET_SUFFIX"
+            echo "BOOST_ARCHITECTURE=$BOOST_ARCHITECTURE"
+            echo "BOOST_ADDRESS_MODEL=$BOOST_ADDRESS_MODEL"
+            echo "BOOST_ABI=$BOOST_ABI"
+          } >> "$GITHUB_ENV"
+
+      - name: Build OpenSSL for Android ${{ matrix.ANDROID_ABI }}
+        if: steps.cache-android-deps.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          archive="$THIRD_PARTY_DIR/openssl-${OPENSSL_VERSION}.tar.gz"
+          extract="$THIRD_PARTY_DIR/openssl-${OPENSSL_VERSION}"
+
+          if [ ! -f "$OPENSSL_SRC_DIR/Configure" ]; then
+            curl -L --fail -o "$archive" \
+              "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz"
+            rm -rf "$extract" "$OPENSSL_SRC_DIR"
+            tar -xzf "$archive" -C "$THIRD_PARTY_DIR"
+            mv "$extract" "$OPENSSL_SRC_DIR"
+          fi
+
+          rm -rf "$OPENSSL_OUT_DIR"
+          mkdir -p "$OPENSSL_OUT_DIR"
+
+          cd "$OPENSSL_SRC_DIR"
+          export ANDROID_NDK_HOME="$NDK_ROOT"
+          export ANDROID_NDK_ROOT="$NDK_ROOT"
+          export PATH="$TOOLCHAIN_DIR/bin:$PATH"
+          export CFLAGS="-fPIC"
+          export CXXFLAGS="-fPIC"
+
+          make clean >/dev/null 2>&1 || true
+          ./Configure "$OPENSSL_TARGET" -D__ANDROID_API__="$ANDROID_API" \
+            --prefix="$OPENSSL_OUT_DIR" \
+            no-shared no-tests no-module no-asm
+          make -j"$(nproc)"
+          make install_sw
+
+      - name: Build Boost for Android ${{ matrix.ANDROID_ABI }}
+        if: steps.cache-android-deps.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          boost_lib_version="$(printf '%s' "$BOOST_VERSION" | sed 's/\./_/g')"
+          archive="$THIRD_PARTY_DIR/boost_${boost_lib_version}.tar.bz2"
+          extract="$THIRD_PARTY_DIR/boost_${boost_lib_version}"
+
+          if [ ! -f "$BOOST_SRC_DIR/boost/version.hpp" ] || \
+            ! grep -q "BOOST_LIB_VERSION \"$boost_lib_version\"" "$BOOST_SRC_DIR/boost/version.hpp"; then
+            curl -L --fail -o "$archive" \
+              "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${boost_lib_version}.tar.bz2"
+            rm -rf "$extract" "$BOOST_SRC_DIR"
+            tar -xjf "$archive" -C "$THIRD_PARTY_DIR"
+            mv "$extract" "$BOOST_SRC_DIR"
+          fi
+
+          rm -rf "$BOOST_OUT_DIR"
+          mkdir -p "$BOOST_OUT_DIR"
+
+          user_config="$(mktemp)"
+          cat > "$user_config" <<EOF
+          using clang : $BOOST_TOOLSET_SUFFIX : $TOOLCHAIN_DIR/bin/${CLANG_TRIPLE}${ANDROID_API}-clang++ :
+              <archiver>$TOOLCHAIN_DIR/bin/llvm-ar
+              <ranlib>$TOOLCHAIN_DIR/bin/llvm-ranlib
+              <compileflags>--target=${CLANG_TRIPLE}${ANDROID_API}
+              <compileflags>--sysroot=$TOOLCHAIN_DIR/sysroot
+              <compileflags>-fPIC
+              <compileflags>-std=c++17
+              <compileflags>-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION
+              <linkflags>--target=${CLANG_TRIPLE}${ANDROID_API}
+              <linkflags>--sysroot=$TOOLCHAIN_DIR/sysroot
+          ;
+          EOF
+
+          cd "$BOOST_SRC_DIR"
+          if [ ! -x ./b2 ]; then
+            ./bootstrap.sh --with-toolset=clang
+          fi
+
+          ./b2 -j"$(nproc)" \
+            --user-config="$user_config" \
+            --build-dir="$BOOST_OUT_DIR/build" \
+            toolset=clang-$BOOST_TOOLSET_SUFFIX \
+            target-os=android \
+            binary-format=elf \
+            architecture=$BOOST_ARCHITECTURE \
+            address-model=$BOOST_ADDRESS_MODEL \
+            abi=$BOOST_ABI \
+            context-impl=fcontext \
+            link=static \
+            threading=multi \
+            runtime-link=static \
+            variant=release \
+            --with-system \
+            --with-coroutine \
+            --with-thread \
+            --with-context \
+            --with-regex \
+            --with-filesystem \
+            --stagedir="$BOOST_OUT_DIR/stage" \
+            stage
+
+          rm -f "$user_config"
+          find "$BOOST_OUT_DIR/stage/lib" -type f -name 'libboost_*.a' -exec cp {} "$BOOST_OUT_DIR/" \;
+
+          for lib in system coroutine thread context regex filesystem; do
+            test -f "$BOOST_OUT_DIR/libboost_${lib}.a"
+          done
+          nm_output="$("$TOOLCHAIN_DIR/bin/llvm-nm" -g "$BOOST_OUT_DIR/libboost_context.a")"
+          printf '%s\n' "$nm_output" | grep -Eq ' (make_fcontext)$'
+          printf '%s\n' "$nm_output" | grep -Eq ' (jump_fcontext)$'
+          printf '%s\n' "$nm_output" | grep -Eq ' (ontop_fcontext)$'
+
+      - name: Verify Android third-party dependencies
+        run: |
+          set -euo pipefail
+          test -f "$OPENSSL_OUT_DIR/lib/libssl.a"
+          test -f "$OPENSSL_OUT_DIR/lib/libcrypto.a"
+          test -d "$OPENSSL_OUT_DIR/include/openssl"
+          test -f "$BOOST_SRC_DIR/boost/version.hpp"
+          for lib in system coroutine thread context regex filesystem; do
+            test -f "$BOOST_OUT_DIR/libboost_${lib}.a"
+          done
+          nm_output="$("$TOOLCHAIN_DIR/bin/llvm-nm" -g "$BOOST_OUT_DIR/libboost_context.a")"
+          printf '%s\n' "$nm_output" | grep -Eq ' (make_fcontext)$'
+          printf '%s\n' "$nm_output" | grep -Eq ' (jump_fcontext)$'
+          printf '%s\n' "$nm_output" | grep -Eq ' (ontop_fcontext)$'
+
+      - name: Patch Android CMake for generated dependencies
+        run: |
+          set -euo pipefail
+          echo "CMakeLists.txt already adapted in inet6"
+          grep -n "THIRD_PARTY_LIBRARY_DIR\|OPENPPP2_ANDROID_STATIC_LIBS\|CMAKE_CXX_STANDARD" \
+            openppp2/android/CMakeLists.txt
 
       - name: Build openppp2
         run: |
-          NDK_ROOT="${{ runner.temp }}/ndk/abi"
-          TP="${{ runner.temp }}/ndk"
-          export PPP_ANDROID_ABI=${{ matrix.ppp_abi }}
+          set -euo pipefail
+          build_dir="openppp2/build/android-actions/${ANDROID_ABI}"
+          output_dir="$GITHUB_WORKSPACE/openppp2/bin/android/${ANDROID_ABI}"
+          rm -rf "$build_dir"
+          mkdir -p "$build_dir" "$output_dir"
 
-          cd android && mkdir -p build && cd build
-          cmake .. \
+          # C++17 与 Boost 1.86 部分 deprecated API 不兼容，强制降为 C++14
+
+          cd "$build_dir"
+          cmake "$GITHUB_WORKSPACE/openppp2/android" \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_TOOLCHAIN_FILE="${NDK_ROOT}/build/cmake/android.toolchain.cmake" \
             -DCMAKE_SYSTEM_NAME=Android \
-            -DANDROID_ABI=${{ matrix.abi }} \
-            -DANDROID_NATIVE_API_LEVEL=21 \
+            -DANDROID_ABI="${ANDROID_ABI}" \
+            -DANDROID_NATIVE_API_LEVEL="${ANDROID_API}" \
             -DANDROID_STL=c++_static \
-            -DTHIRD_PARTY_LIBRARY_DIR="$TP"
-          make -j$(nproc)
+            -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$output_dir" \
+            -DTHIRD_PARTY_LIBRARY_DIR="$THIRD_PARTY_DIR" \
+            -DBOOST_ANDROID_INCLUDE_DIR="$BOOST_SRC_DIR" \
+            -DBOOST_ANDROID_LIB_DIR="$BOOST_OUT_DIR" \
+            -DOPENSSL_ANDROID_ROOT="$OPENSSL_OUT_DIR"
+          make -j"$(nproc)"
 
       - name: Package artifact
         run: |
-          ARTIFACT=openppp2-android-${{ matrix.abi }}.zip
+          ARTIFACT=openppp2-android-${{ env.ANDROID_ABI }}-ubuntu.zip
           echo "ARTIFACT=$ARTIFACT" >> $GITHUB_ENV
-          cd bin/android/${{ matrix.abi }}
+          cd "$GITHUB_WORKSPACE/openppp2/bin/android/${{ env.ANDROID_ABI }}"
           zip -r "$ARTIFACT" libopenppp2.so
           mv "$ARTIFACT" ../../
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Android library
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT }}
-          path: bin/${{ env.ARTIFACT }}
+          path: openppp2/bin/${{ env.ARTIFACT }}
           if-no-files-found: error
+
 
   build-apk:
     name: Build Flutter APK
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build-so]
+
+    env:
+      APK_NAME: openppp2-android.apk
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Download all .so artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: so-artifacts
-          pattern: openppp2-android-*.zip
-
-      - name: Extract .so into jniLibs
+      - name: Generate app version
         run: |
-          for zip in so-artifacts/openppp2-android-*.zip/openppp2-android-*.zip; do
-            abi=$(basename "$zip" | sed 's/openppp2-android-//;s/\.zip//')
-            mkdir -p "android/android/app/src/main/jniLibs/${abi}"
-            unzip -o "$zip" -d "android/android/app/src/main/jniLibs/${abi}"
+          DATE=$(TZ='Asia/Shanghai' date +'%Y%m%d%H%M%S')
+          echo "app_version=1.0.0-${DATE}" >> $GITHUB_ENV
+
+      - name: Checkout openppp2 repository
+        uses: actions/checkout@v6
+        with:
+          repository: rebecca554owen/openppp2
+          path: openppp2
+          ref: inet6
+
+      - name: Download .so artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: so-artifacts-downloaded
+
+      - name: Copy .so into jniLibs
+        run: |
+          set -euo pipefail
+          mapfile -t zips < <(find so-artifacts-downloaded -type f -name 'openppp2-android-*-ubuntu.zip' | sort)
+          if [ ${#zips[@]} -eq 0 ]; then
+            echo "::error::No openppp2-android-*-ubuntu.zip found under so-artifacts-downloaded"
+            find so-artifacts-downloaded -maxdepth 3 -type f -o -type d | sort
+            exit 1
+          fi
+          for zip in "${zips[@]}"; do
+            abi=$(basename "$zip" .zip | sed 's/^openppp2-android-//;s/-ubuntu$//')
+            mkdir -p "openppp2/android/android/app/src/main/jniLibs/${abi}"
+            unzip -o "$zip" -d "openppp2/android/android/app/src/main/jniLibs/${abi}"
           done
           echo "=== jniLibs tree ==="
-          find android/android/app/src/main/jniLibs -type f
+          find openppp2/android/android/app/src/main/jniLibs -type f
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -133,10 +356,10 @@ jobs:
           channel: stable
           cache: true
 
-      - name: Flutter doctor & pub get
+      - name: Flutter doctor and pub get
         run: |
           flutter doctor -v
-          cd android && flutter pub get
+          cd openppp2/android && flutter pub get
 
       - name: Configure Android release signing
         env:
@@ -145,6 +368,7 @@ jobs:
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
+          cd openppp2
           required=(ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD)
           for name in "${required[@]}"; do
             if [ -z "${!name}" ]; then
@@ -164,17 +388,18 @@ jobs:
 
       - name: Build release APK
         run: |
-          cd android
+          cd openppp2/android
           flutter build apk --release
 
-      - name: Verify signed APK
+      - name: Rename APK
         run: |
-          ${ANDROID_HOME}/build-tools/$(ls ${ANDROID_HOME}/build-tools | sort -V | tail -n 1)/apksigner verify \
-            --verbose --print-certs android/build/app/outputs/flutter-apk/app-release.apk
+          cp openppp2/android/build/app/outputs/flutter-apk/app-release.apk "${{ env.APK_NAME }}"
+          test -f "${{ env.APK_NAME }}"
 
-      - name: Upload signed APK
-        uses: actions/upload-artifact@v4
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v7
         with:
-          name: openppp2-android-signed-apk
-          path: android/build/app/outputs/flutter-apk/app-release.apk
+          name: ${{ env.APK_NAME }}
+          path: ${{ env.APK_NAME }}
           if-no-files-found: error
+

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,8 +1,8 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 # Define the solutions name.
 SET(NAME openppp2)
-PROJECT(${NAME} C CXX) # CMAKE_CURRENT_SOURCE_DIR
+PROJECT(${NAME} VERSION 2.0.0.0 LANGUAGES C CXX) # CMAKE_CURRENT_SOURCE_DIR
 
 # C/CXX compiler configurations.
 SET(CMAKE_C_FLAGS "-fPIC -fvisibility=hidden -Wno-format -Wno-implicit-function-declaration")
@@ -13,7 +13,6 @@ ADD_DEFINITIONS(-D_ANDROID)
 ADD_DEFINITIONS(-D_LINUX)
 ADD_DEFINITIONS(-DFUNCTION)
 ADD_DEFINITIONS(-DBUDDY_ALLOC_IMPLEMENTATION)
-ADD_DEFINITIONS(-D_ANDROID_REDEF_STD_IN_OUT_ERR)
 SET(PROJECT_ROOT_DIR "${PROJECT_SOURCE_DIR}/../")
 
 # ENV.
@@ -79,7 +78,34 @@ SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++ -rdynamic -Wl,-Bstatic")
 
 # Set the tripartite library directorys.
-SET(THIRD_PARTY_LIBRARY_DIR /root/android CACHE PATH "Third-party library root directory")
+SET(THIRD_PARTY_LIBRARY_DIR "${PROJECT_ROOT_DIR}/third-party" CACHE PATH "Android third-party root directory")
+
+IF(NOT ANDROID_ABI)
+    MESSAGE(FATAL_ERROR "ANDROID_ABI is required for the Android build.")
+ENDIF()
+
+SET(BOOST_ANDROID_LIB_DIR "${THIRD_PARTY_LIBRARY_DIR}/boost/${ANDROID_ABI}" CACHE PATH "Android Boost static library directory")
+SET(OPENSSL_ANDROID_ROOT "${THIRD_PARTY_LIBRARY_DIR}/openssl-${ANDROID_ABI}" CACHE PATH "Android OpenSSL install root")
+SET(BOOST_ANDROID_INCLUDE_DIR "${THIRD_PARTY_LIBRARY_DIR}/boost-src" CACHE PATH "Android Boost include directory")
+SET(OPENSSL_ANDROID_INCLUDE_DIR "${OPENSSL_ANDROID_ROOT}/include")
+SET(OPENSSL_ANDROID_LIB_DIR "${OPENSSL_ANDROID_ROOT}/lib")
+
+SET(OPENPPP2_ANDROID_STATIC_LIBS
+    "${OPENSSL_ANDROID_LIB_DIR}/libssl.a"
+    "${OPENSSL_ANDROID_LIB_DIR}/libcrypto.a"
+    "${BOOST_ANDROID_LIB_DIR}/libboost_system.a"
+    "${BOOST_ANDROID_LIB_DIR}/libboost_coroutine.a"
+    "${BOOST_ANDROID_LIB_DIR}/libboost_thread.a"
+    "${BOOST_ANDROID_LIB_DIR}/libboost_context.a"
+    "${BOOST_ANDROID_LIB_DIR}/libboost_regex.a"
+    "${BOOST_ANDROID_LIB_DIR}/libboost_filesystem.a"
+)
+
+FOREACH(OPENPPP2_STATIC_LIB ${OPENPPP2_ANDROID_STATIC_LIBS})
+    IF(NOT EXISTS "${OPENPPP2_STATIC_LIB}")
+        MESSAGE(FATAL_ERROR "Missing Android static dependency: ${OPENPPP2_STATIC_LIB}")
+    ENDIF()
+ENDFOREACH()
 
 # Set the compiled header file search directorys.
 INCLUDE_DIRECTORIES(
@@ -89,14 +115,8 @@ INCLUDE_DIRECTORIES(
     ${PROJECT_ROOT_DIR}/common/lwip/my
     ${PROJECT_ROOT_DIR}/common/lwip/include
 
-    ${THIRD_PARTY_LIBRARY_DIR}/boost
-    ${THIRD_PARTY_LIBRARY_DIR}/openssl/$ENV{PPP_ANDROID_ABI}/include
-)
-
-# Set the third library connection directory to searchs.
-LINK_DIRECTORIES(
-    ${THIRD_PARTY_LIBRARY_DIR}/boost/$ENV{PPP_ANDROID_ABI}
-    ${THIRD_PARTY_LIBRARY_DIR}/openssl/$ENV{PPP_ANDROID_ABI}/lib
+    ${BOOST_ANDROID_INCLUDE_DIR}
+    ${OPENSSL_ANDROID_INCLUDE_DIR}
 )
 
 SET(BUILD_SHARED_LIBS ON)
@@ -132,20 +152,8 @@ FILE(GLOB_RECURSE SOURCE_FILES
 # Add the compiled output binary files.
 ADD_LIBRARY(${NAME} SHARED ${SOURCE_FILES} ${PLATFORM_SOURCE_FILES} ${AES_NI_SOURCE_FILES})
 
-# Set the compilation output files path.
-SET(LIBRARY_OUTPUT_PATH ${PROJECT_ROOT_DIR}/bin/android/${ANDROID_ABI})
-
 # Set up library connections to dependent libraries.
 TARGET_LINK_LIBRARIES(${NAME}
-    libssl.a
-    libcrypto.a
-
+    ${OPENPPP2_ANDROID_STATIC_LIBS}
     log
-    dl
-
-    libboost_system.a
-    libboost_coroutine.a
-    libboost_thread.a
-    libboost_context.a
-    libboost_regex.a
-    libboost_filesystem.a)
+    dl)


### PR DESCRIPTION
## Summary
- Rewrite Android CI workflow for NDK r26b with source-built third-party libraries.
- Drop `_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION` workaround.

## Test plan
- CI passes on `inet6` branch for Android APK builds.