### PR TITLE
fix: repair full-build incomplete-type error and unit-test link failure

### DIFF
--- a/ppp/app/client/PeerPrefixRouteManager.cpp
+++ b/ppp/app/client/PeerPrefixRouteManager.cpp
@@ -2,6 +2,7 @@
 #include <ppp/app/client/VEthernetNetworkSwitcher.h>
 #include <ppp/app/client/RouteTableManager.h>
 #include <ppp/app/protocol/PeerPrefixRoute.h>
+#include <ppp/app/protocol/VirtualEthernetInformation.h>
 #include <ppp/configurations/AppConfiguration.h>
 #include <ppp/diagnostics/TelemetryFwd.h>
 #include <ppp/diagnostics/Telemetry.h>

--- a/tests/cpp/support/dns_host_wiring_switcher_stub.cpp
+++ b/tests/cpp/support/dns_host_wiring_switcher_stub.cpp
@@ -259,6 +259,10 @@ VEthernetNetworkSwitcher::ITransmissionStatisticsPtr VEthernetNetworkSwitcher::N
 VEthernetNetworkSwitcher::ProtectorNetworkPtr VEthernetNetworkSwitcher::NewProtectorNetwork() noexcept {
     return ProtectorNetworkPtr();
 }
+
+VEthernetNetworkSwitcher::ProtectorNetworkPtr VEthernetNetworkSwitcher::GetProtectorNetwork() noexcept {
+    return ProtectorNetworkPtr();
+}
 #endif
 
 #if !defined(_ANDROID) && !defined(_IPHONE)


### PR DESCRIPTION
## Summary

项目中原本存在两个较小且相互独立的问题，导致项目无法在 Linux 上完成编译，C++ 单元测试也无法成功链接。

## 问题 1：`PeerPrefixRouteManager.cpp` 导致所有完整构建失败

`PeerPrefixRouteManager.h` 仅对
`VirtualEthernetInformationExtensions` 进行了前置声明，但 `.cpp` 文件在当前作用域中只有该前置声明的情况下，直接访问了它的成员 `extensions.PeerRouteTable`：

```
PeerPrefixRouteManager.cpp:67:46: error: invalid use of incomplete type
    'const struct ppp::app::protocol::VirtualEthernetInformationExtensions'
PeerPrefixRouteManager.cpp:126:42: error: unable to deduce 'auto&&' from 'dynamic_routes'
```

`:126` 的范围 for 循环错误只是一个连锁错误。由于 `:67` 的初始化表达式使用了不完整类型，`dynamic_routes` 从未获得有效的类型。

修复： 引入完整定义所在的头文件 `ppp/app/protocol/VirtualEthernetInformation.h`。这与其他同级管理器（`AssignedAddressManager`、`VEthernetNetworkSwitcher`、`ClientPacketDispatchHandler`）现有的处理方式一致。

## 问题 2：单元测试链接失败

用于 DNS 主机布线测试的 switcher 桩实现定义了 `NewProtectorNetwork()`，但没有定义 `GetProtectorNetwork()`。

后者同时被该桩实现自身的 `BuildDnsHostPorts lambda` 和 `AggregatorLoader::Prepare()` 引用：

```
undefined reference to
    `ppp::app::client::VEthernetNetworkSwitcher::GetProtectorNetwork()'
```

这会导致 `dns_host_wiring_test` 和 `aggregator_loader_test` 构建失败。

修复： 在现有的 `#if defined(_LINUX)` 条件编译保护中，添加对应的桩函数定义。

## 验证
问题 1： 在未修复的文件上使用 `g++ -fsyntax-only`，成功复现了完全相同的不完整类型错误；添加头文件引用后，确认命令正常结束并返回 `exit 0`。
问题 2： 修复内容与声明 `ProtectorNetworkPtr GetProtectorNetwork() noexcept` 以及周围现有的桩实现模式一致；同时已通过 CI 单元测试链接步骤验证。