### PR TITLE
fix: repair VEthernetNetworkSwitcher full build after RouteHostPorts refactor

### DIFF
--- a/ppp/app/client/PeerPrefixRouteManager.cpp
+++ b/ppp/app/client/PeerPrefixRouteManager.cpp
@@ -2,6 +2,7 @@
 #include <ppp/app/client/VEthernetNetworkSwitcher.h>
 #include <ppp/app/client/RouteTableManager.h>
 #include <ppp/app/protocol/PeerPrefixRoute.h>
+#include <ppp/app/protocol/VirtualEthernetInformation.h>
 #include <ppp/configurations/AppConfiguration.h>
 #include <ppp/diagnostics/TelemetryFwd.h>
 #include <ppp/diagnostics/Telemetry.h>

--- a/ppp/app/client/VEthernetNetworkSwitcher.cpp
+++ b/ppp/app/client/VEthernetNetworkSwitcher.cpp
@@ -142,7 +142,7 @@ namespace ppp {
             VEthernetNetworkSwitcher::VEthernetNetworkSwitcher(const std::shared_ptr<boost::asio::io_context>& context, bool lwip, bool vnet, bool mta, const std::shared_ptr<ppp::configurations::AppConfiguration>& configuration) noexcept
                 : VEthernet(context, lwip, vnet, mta)
                 , configuration_(configuration)
-                , dns_interceptor_(std::make_unique<dns::DnsInterceptor>())
+                , dns_interceptor_(std::make_shared<dns::DnsInterceptor>())
                 , route_table_(std::make_unique<RouteTableManager>())
                 , address_manager_(std::make_unique<AssignedAddressManager>())
                 , teardown_(std::make_unique<ClientConnectionTeardown>())
@@ -178,9 +178,6 @@ namespace ppp {
                 block_quic_      = false;
                 icmppackets_aid_ = RandomNext();
             }
-
-            VEthernetNetworkSwitcher::VEthernetNetworkSwitcher(VEthernetNetworkSwitcher&&) noexcept = default;
-            VEthernetNetworkSwitcher& VEthernetNetworkSwitcher::operator=(VEthernetNetworkSwitcher&&) noexcept = default;
 
             /** @brief Finalizes network switcher on destruction. */
             VEthernetNetworkSwitcher::~VEthernetNetworkSwitcher() noexcept {
@@ -1096,10 +1093,21 @@ namespace ppp {
                     };
                 host.get_dns_interceptor = [self]() noexcept { return self->dns_interceptor_; };
                 host.get_configuration = [self]() noexcept { return self->GetConfiguration(); };
+#if defined(_LINUX)
                 host.get_default_routes = [self]() noexcept { return self->default_routes_; };
                 host.set_default_routes =
                     [self](route::RouteInformationTablePtr routes) noexcept { self->default_routes_ = std::move(routes); };
                 host.get_nics = [self]() noexcept { return &self->nics_; };
+#else
+                // default_routes_/nics_ back only the linux route backend; other platforms keep
+                // these ports valid with empty stand-ins because their route managers never call them.
+                host.get_default_routes = []() noexcept { return route::RouteInformationTablePtr(); };
+                host.set_default_routes = [](route::RouteInformationTablePtr) noexcept {};
+                host.get_nics = []() noexcept -> ppp::unordered_map<uint32_t, ppp::string>* {
+                    static ppp::unordered_map<uint32_t, ppp::string> empty_nics;
+                    return &empty_nics;
+                };
+#endif
                 return host;
             }
 

--- a/ppp/app/client/VEthernetNetworkSwitcher.cpp
+++ b/ppp/app/client/VEthernetNetworkSwitcher.cpp
@@ -1038,9 +1038,9 @@ namespace ppp {
             }
 
             route::RouteHostPorts VEthernetNetworkSwitcher::BuildRouteHostPorts() noexcept {
-                const auto self = std::static_pointer_cast<VEthernetNetworkSwitcher>(shared_from_this());
-
                 route::RouteHostPorts host;
+#if !defined(_ANDROID) && !defined(_IPHONE)
+                const auto self = std::static_pointer_cast<VEthernetNetworkSwitcher>(shared_from_this());
                 host.get_tap = [self]() noexcept { return self->GetTap(); };
 #if !defined(_ANDROID) && !defined(_IPHONE)
                 host.get_tap_ni = [self]() noexcept { return self->GetTapNetworkInterface(); };
@@ -1107,7 +1107,8 @@ namespace ppp {
                     static ppp::unordered_map<uint32_t, ppp::string> empty_nics;
                     return &empty_nics;
                 };
-#endif
+#endif // _LINUX vs other desktops
+#endif // !_ANDROID && !_IPHONE: mobile uses RouteTableManager_mobile, no route-ports consumer
                 return host;
             }
 

--- a/ppp/app/client/VEthernetNetworkSwitcher.h
+++ b/ppp/app/client/VEthernetNetworkSwitcher.h
@@ -98,8 +98,8 @@ namespace ppp {
                 VEthernetNetworkSwitcher(const std::shared_ptr<boost::asio::io_context>& context, bool lwip, bool vnet, bool mta, const std::shared_ptr<ppp::configurations::AppConfiguration>& configuration) noexcept;
                 VEthernetNetworkSwitcher(const VEthernetNetworkSwitcher&) = delete;
                 VEthernetNetworkSwitcher& operator=(const VEthernetNetworkSwitcher&) = delete;
-                VEthernetNetworkSwitcher(VEthernetNetworkSwitcher&&) noexcept;
-                VEthernetNetworkSwitcher& operator=(VEthernetNetworkSwitcher&&) noexcept;
+                VEthernetNetworkSwitcher(VEthernetNetworkSwitcher&&) noexcept = delete;
+                VEthernetNetworkSwitcher& operator=(VEthernetNetworkSwitcher&&) noexcept = delete;
                 virtual ~VEthernetNetworkSwitcher() noexcept;
 
 #include <ppp/app/client/VEthernetNetworkSwitcherPublicMethods.inc>

--- a/ppp/app/client/VEthernetNetworkSwitcherMembers.inc
+++ b/ppp/app/client/VEthernetNetworkSwitcherMembers.inc
@@ -16,7 +16,7 @@
                 VEthernetHttpProxySwitcherPtr                                       http_proxy_;
                 VEthernetSocksProxySwitcherPtr                                      socks_proxy_;
                 std::unique_ptr<SwitcherTimeoutRegistry>                            timeout_registry_;
-                std::unique_ptr<dns::DnsInterceptor>                                dns_interceptor_;
+                std::shared_ptr<dns::DnsInterceptor>                                dns_interceptor_;
                 RouteInformationTablePtr                                            rib_;
                 ForwardInformationTablePtr                                          fib_;
                 RouteInformationTablePtr                                            peer_prefix_rib_;

--- a/ppp/app/client/proxys/VEthernetHttpProxySwitcher.cpp
+++ b/ppp/app/client/proxys/VEthernetHttpProxySwitcher.cpp
@@ -1,6 +1,7 @@
 #include <ppp/app/client/proxys/VEthernetHttpProxySwitcher.h>
 #include <ppp/app/client/proxys/VEthernetHttpProxyConnection.h>
 #include <ppp/app/client/VEthernetExchanger.h>
+#include <ppp/configurations/AppConfiguration.h>
 #include <ppp/net/Ipep.h>
 #include <ppp/net/Socket.h>
 #include <ppp/threading/Timer.h>

--- a/ppp/app/client/proxys/VEthernetSocksProxyConnection.cpp
+++ b/ppp/app/client/proxys/VEthernetSocksProxyConnection.cpp
@@ -1,6 +1,7 @@
 #include <ppp/app/protocol/VirtualEthernetTcpipConnection.h>
 #include <ppp/app/client/VEthernetExchanger.h>
 #include <ppp/app/client/VEthernetNetworkSwitcher.h>
+#include <ppp/configurations/AppConfiguration.h>
 #include <ppp/app/client/VEthernetNetworkTcpipConnection.h>
 #include <ppp/app/client/proxys/VEthernetSocksProxySwitcher.h>
 #include <ppp/app/client/proxys/VEthernetSocksProxyConnection.h>

--- a/ppp/app/client/proxys/VEthernetSocksProxySwitcher.cpp
+++ b/ppp/app/client/proxys/VEthernetSocksProxySwitcher.cpp
@@ -1,6 +1,7 @@
 #include <ppp/app/client/proxys/VEthernetSocksProxySwitcher.h>
 #include <ppp/app/client/proxys/VEthernetSocksProxyConnection.h>
 #include <ppp/app/client/VEthernetExchanger.h>
+#include <ppp/configurations/AppConfiguration.h>
 #include <ppp/net/Ipep.h>
 #include <ppp/net/Socket.h>
 #include <ppp/threading/Timer.h>

--- a/tests/cpp/support/dns_host_wiring_switcher_stub.cpp
+++ b/tests/cpp/support/dns_host_wiring_switcher_stub.cpp
@@ -259,6 +259,10 @@ VEthernetNetworkSwitcher::ITransmissionStatisticsPtr VEthernetNetworkSwitcher::N
 VEthernetNetworkSwitcher::ProtectorNetworkPtr VEthernetNetworkSwitcher::NewProtectorNetwork() noexcept {
     return ProtectorNetworkPtr();
 }
+
+VEthernetNetworkSwitcher::ProtectorNetworkPtr VEthernetNetworkSwitcher::GetProtectorNetwork() noexcept {
+    return ProtectorNetworkPtr();
+}
 #endif
 
 #if !defined(_ANDROID) && !defined(_IPHONE)


### PR DESCRIPTION
下面的内容是我让 Copilot 生成的，我懒得翻译中文了。

主要和 #36 一样，是修改编译错误。但应该先合并 #36，因为我在修完它后又被几个错误卡住了，干脆一股脑把剩下的问题修了，于是就有了这个 PR。

## Summary

The RouteHostPorts refactor left `VEthernetNetworkSwitcher.cpp` uncompilable in
full builds on every platform. Full builds only surface this once the
incomplete-type fix lets compilation advance past `PeerPrefixRouteManager.cpp`
(that earlier break masked these via an aborted `make`).

## Three independent breaks

**1. Defaulted move over non-movable members**

`VEthernetNetworkSwitcher` derives from `VEthernet` (holds `std::atomic` /
`std::mutex`) and owns several `unique_ptr` members, yet declared `= default`
move ctor/assign. atomic/mutex have no move (only deleted copy), so the
defaulted move is itself deleted:

```
error: use of deleted function 'VEthernet::VEthernet(const VEthernet&)'
```

It is an `enable_shared_from_this` object only ever held via `shared_ptr`, so it
should be non-movable → move ctor/assign changed to `= delete`, out-of-line
definitions removed.

**2. `get_dns_interceptor` returns a `unique_ptr` by value**

The `RouteHostPorts::get_dns_interceptor` contract, its linux consumer, and the
test stub all use `shared_ptr<DnsInterceptor>`, but the member stayed
`unique_ptr`, so the lambda copied a `unique_ptr`:

```
error: use of deleted function 'unique_ptr(const unique_ptr&)'
```

→ `dns_interceptor_` changed to `shared_ptr` to match the port contract (all
borrow sites use `->` / null-checks and are unaffected).

**3. `BuildRouteHostPorts` touches linux-only members on macOS/windows**

`default_routes_` and `nics_` are declared only under `_LINUX` (Windows even has
an unrelated `default_routes_` of a different type), yet `BuildRouteHostPorts`
referenced them unconditionally — breaking macOS (`no member`) and Windows
(type mismatch). Only `RouteTableManager_linux` consumes these ports → they are
now guarded: linux binds the real members, other platforms get empty stand-ins.

## Verification

Reproduced each break and confirmed a clean compile after the fix via
`g++ -fsyntax-only` on `VEthernetNetworkSwitcher.cpp` and
`RouteTableManager_linux.cpp`; macOS/windows validated by CI.